### PR TITLE
Update git hook.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   "lint-staged": {
     "**/*.sol": [
       "npm run lint:sol",
-      "npm run lint:sol:prettier:fix",
       "git add"
     ],
     "test/**": [


### PR DESCRIPTION
This PR remove unnecessary command from git hook. Basically `npm run lint:sol:prettier:fix` will fix linting error, but that command will never get executed as the hook fail if there are linting errors.

Will be better to just execute that command manually to fix linting, as it sometime move lines/indentations in an ugly way.