### PR TITLE
WETH implementation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
     working_directory: ~/gammaprotocol
     docker:
       - image: circleci/node:10.18.0
-      - image: trufflesuite/ganache-cli:v6.7.0
+      - image: trufflesuite/ganache-cli:v6.9.1
         command: ganache-cli --deterministic -e 300 -p 8545 -m 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat' --accounts 30 --allowUnlimitedContractSize
     
     steps:

--- a/.solcover.js
+++ b/.solcover.js
@@ -13,6 +13,7 @@ module.exports = {
     'packages/oz/Create2.sol',
     'packages/oz/upgradeability/ContextUpgradeSafe.sol',
     'packages/oz/upgradeability/ERC20Initializable.sol',
-    'packages/oz/upgradeability/Initializable.sol'
+    'packages/oz/upgradeability/Initializable.sol',
+    'packages/caconical-weth/WETH9.sol'
   ]
 }

--- a/.solcover.js
+++ b/.solcover.js
@@ -14,6 +14,6 @@ module.exports = {
     'packages/oz/upgradeability/ContextUpgradeSafe.sol',
     'packages/oz/upgradeability/ERC20Initializable.sol',
     'packages/oz/upgradeability/Initializable.sol',
-    'packages/caconical-weth/WETH9.sol'
+    'packages/canonical-weth/WETH9.sol'
   ]
 }

--- a/contracts/packages/canonical-weth/WETH9.sol
+++ b/contracts/packages/canonical-weth/WETH9.sol
@@ -1,0 +1,126 @@
+// Copyright (C) 2015, 2016, 2017 Dapphub
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// SPDX-License-Identifier:  GNU GPL
+pragma solidity 0.6.10;
+
+/**
+ * @author Opyn Team
+ * @title WETH contract
+ * @dev A wrapper to use ETH as collateral
+ */
+contract WETH9 {
+    string public name = "Wrapped Ether";
+    string public symbol = "WETH";
+    uint8 public decimals = 18;
+
+    /// @notice emmitted when a sender approve WETH transfer
+    event Approval(address indexed src, address indexed guy, uint256 wad);
+    /// @notice emmitted when a sender transfer WETH
+    event Transfer(address indexed src, address indexed dst, uint256 wad);
+    /// @notice emitted when a sender deposit ETH into this contract
+    event Deposit(address indexed dst, uint256 wad);
+    /// @notice emmited when a sender withdraw ETH from this contract
+    event Withdrawal(address indexed src, uint256 wad);
+
+    /// @notice mapping between address and WETH balance
+    mapping(address => uint256) public balanceOf;
+    /// @notice mapping between addresses and allowance amount
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    /**
+     * @notice fallback function that receive ETH
+     * @dev will get called in a tx with
+     */
+    receive() external payable {
+        deposit();
+    }
+
+    /**
+     * @notice Wrap deposited ETH into WETH
+     */
+    function deposit() public payable {
+        balanceOf[msg.sender] += msg.value;
+        emit Deposit(msg.sender, msg.value);
+    }
+
+    /**
+     * @notice withdraw ETH from contract
+     * @dev Unwrap from WETH to ETH
+     * @param _wad amount WETH to unwrap and withdraw
+     */
+    function withdraw(uint256 _wad) public {
+        require(balanceOf[msg.sender] >= _wad, "WETH9: insufficient sender balance");
+        balanceOf[msg.sender] -= _wad;
+        msg.sender.transfer(_wad);
+        emit Withdrawal(msg.sender, _wad);
+    }
+
+    /**
+     * @notice get ETH total supply
+     * @return total supply
+     */
+    function totalSupply() public view returns (uint256) {
+        return address(this).balance;
+    }
+
+    /**
+     * @notice approve transfer
+     * @param _guy address to approve
+     * @param _wad amount of WETH
+     * @return true if tx succeeded
+     */
+    function approve(address _guy, uint256 _wad) public returns (bool) {
+        allowance[msg.sender][_guy] = _wad;
+        emit Approval(msg.sender, _guy, _wad);
+        return true;
+    }
+
+    /**
+     * @notice transfer WETH
+     * @param _dst destination address
+     * @param _wad amount to transfer
+     * @return true if tx succeeded
+     */
+    function transfer(address _dst, uint256 _wad) public returns (bool) {
+        return transferFrom(msg.sender, _dst, _wad);
+    }
+
+    /**
+     * @notice transfer from address
+     * @param _src source address
+     * @param _dst destination address
+     * @param _wad amount to transfer
+     * @return true if tx succeeded
+     */
+    function transferFrom(
+        address _src,
+        address _dst,
+        uint256 _wad
+    ) public returns (bool) {
+        require(balanceOf[_src] >= _wad, "WETH9: insufficient source balance");
+
+        if (_src != msg.sender && allowance[_src][msg.sender] != uint256(-1)) {
+            require(allowance[_src][msg.sender] >= _wad, "WETH9: invalid allowance");
+            allowance[_src][msg.sender] -= _wad;
+        }
+
+        balanceOf[_src] -= _wad;
+        balanceOf[_dst] += _wad;
+
+        emit Transfer(_src, _dst, _wad);
+
+        return true;
+    }
+}

--- a/test/weth9.test.ts
+++ b/test/weth9.test.ts
@@ -1,0 +1,106 @@
+import {WETH9Instance} from '../build/types/truffle-types'
+const BigNumber = require('bignumber.js')
+const {expectEvent, expectRevert} = require('@openzeppelin/test-helpers')
+const WETH9 = artifacts.require('WETH9.sol')
+// address(0)
+const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
+
+contract('WETH9', ([sender]) => {
+  let weth: WETH9Instance
+
+  const underlyingAsset = ZERO_ADDR
+
+  before('Deployment', async () => {
+    // deploy USDC token
+    weth = await WETH9.new()
+  })
+
+  describe('Send ETH', () => {
+    /*it('should revert whitelisting a product from non-owner address', async () => {
+        await expectRevert(
+            whitelist.whitelistProduct(underlyingAsset, usdc.address, usdc.address, {from: random}),
+            'Ownable: caller is not the owner',
+        )
+        })*/
+
+    it('should increase WETH balance and total supply when sending a transaction to contract', async () => {
+      const balanceBefore = new BigNumber(await weth.balanceOf(sender))
+      const totalSuppluBefore = new BigNumber(await weth.totalSupply())
+
+      const value = new BigNumber(web3.utils.toWei('1', 'ether'))
+
+      await web3.eth.sendTransaction({
+        from: sender,
+        to: weth.address,
+        value: value,
+      })
+
+      const balanceAfter = new BigNumber(await weth.balanceOf(sender))
+      const totalSupplyAfter = new BigNumber(await weth.totalSupply())
+
+      assert.equal(
+        value.toString(),
+        balanceAfter.minus(balanceBefore).toString(),
+        'Wrapped ETH amount mismatch when calling fallback',
+      )
+      assert.equal(
+        value.toString(),
+        totalSupplyAfter.minus(totalSuppluBefore).toString(),
+        'Total supply mismatch when calling fallback',
+      )
+    })
+
+    it('should increase WETH and total supply when depositing ETH', async () => {
+      const balanceBefore = new BigNumber(await weth.balanceOf(sender))
+      const totalSuppluBefore = new BigNumber(await weth.totalSupply())
+
+      const value = new BigNumber(web3.utils.toWei('1', 'ether'))
+
+      await weth.deposit({from: sender, value: value})
+
+      const balanceAfter = new BigNumber(await weth.balanceOf(sender))
+      const totalSupplyAfter = new BigNumber(await weth.totalSupply())
+
+      assert.equal(
+        value.toString(),
+        balanceAfter.minus(balanceBefore).toString(),
+        'Wrapped ETH amount mismatch when calling deposit',
+      )
+      assert.equal(
+        value.toString(),
+        totalSupplyAfter.minus(totalSuppluBefore).toString(),
+        'Total supply mismatch when calling deposit',
+      )
+    })
+  })
+
+  describe('Withdraw ETH', () => {
+    it('should decrease WETH balance, total supply and increase ETH when withdrawing', async () => {
+      const balanceBefore = new BigNumber(await weth.balanceOf(sender))
+      const totalSuppluBefore = new BigNumber(await weth.totalSupply())
+
+      const value = new BigNumber(web3.utils.toWei('1', 'ether'))
+
+      const tx = await weth.withdraw(value, {from: sender})
+
+      expectEvent(tx, 'Withdrawal', {
+        src: sender,
+        wad: value.toString(),
+      })
+
+      const balanceAfter = new BigNumber(await weth.balanceOf(sender))
+      const totalSupplyAfter = new BigNumber(await weth.totalSupply())
+
+      assert.equal(
+        value.toString(),
+        balanceBefore.minus(balanceAfter).toString(),
+        'Wrapped ETH amount mismatch when calling withdraw',
+      )
+      assert.equal(
+        value.toString(),
+        totalSuppluBefore.minus(totalSupplyAfter).toString(),
+        'Total supply mismatch when calling withdraw',
+      )
+    })
+  })
+})


### PR DESCRIPTION
This PR add the needed code to wrap and unwrap ETH for users using [gnosis canonical-weth package](https://github.com/gnosis/canonical-weth).

In the case of transferring ETH into the system, the `Controller` will call the `deposit()` in WETH9 contract to wrap the ETH,  then treat as any other ERC20 and call `transferToPool()` passing the `address(this)` as sender.

In the case of transferring ETH out of the system, the `Controller` will call `transferToUser()` in the `MarginPool` passing `address(this)` as user arg, then call the `withdraw()` in `weth9` to unwrap the ETH and then transfer it out to user.

Will add more details in the spec.