### PR TITLE
Update fixed point library

### DIFF
--- a/contracts/libs/FixedPointInt256.sol
+++ b/contracts/libs/FixedPointInt256.sol
@@ -13,70 +13,59 @@ library FixedPointInt256 {
 
     int256 private constant SCALING_FACTOR = 1e18;
 
-    /**
-     * @notice convert an unsigned integer to signed integer
-     * @param a uint to convert into a signed integer.
-     * @return the converted signed integer.
-     */
-    function uintToInt(uint256 a) internal pure returns (int256) {
-        require(a < uint256(-1), "FixedPointInt256: out of int range");
-
-        return int256(a);
+    struct FixedPointInt {
+        int256 value;
     }
 
     /**
-     * @notice convert a signed integer to unsigned integer
-     * @param a int to convert into an unsigned integer.
-     * @return the converted unsigned integer.
+     * @notice Constructs an `FixedPointInt` from an unscaled int, e.g., `b=5` gets stored internally as `5**18`.
+     * @param a int to convert into a FixedPoint.
+     * @return the converted FixedPoint.
      */
-    function intToUint(int256 a) internal pure returns (uint256) {
-        if (a < 0) {
-            return uint256(-a);
-        } else {
-            return uint256(a);
-        }
+    function fromUnscaledInt(int256 a) internal pure returns (FixedPointInt memory) {
+        return FixedPointInt(a.mul(SCALING_FACTOR));
     }
 
     /**
      * @notice return the sum of two signed integer
-     * @param a signed integer
-     * @param b signed integer
+     * @param a FixedPoint
+     * @param b FixedPoint
      * @return sum of two signed integer
      */
-    function add(int256 a, int256 b) internal pure returns (int256) {
-        return a.add(b);
+    function add(FixedPointInt memory a, FixedPointInt memory b) internal pure returns (FixedPointInt memory) {
+        return FixedPointInt(a.value.add(b.value));
     }
 
     /**
      * @notice return the difference of two signed integer
-     * @param a signed integer
-     * @param b signed integer
-     * @return difference of two signed integer
+     * @param a FixedPoint
+     * @param b FixedPoint
+     * @return difference of two fixed point
      */
-    function sub(int256 a, int256 b) internal pure returns (int256) {
-        return a.sub(b);
+    function sub(FixedPointInt memory a, FixedPointInt memory b) internal pure returns (FixedPointInt memory) {
+        return FixedPointInt(a.value.sub(b.value));
     }
 
     /**
      * @notice multiply two signed integer
      * @dev rounds to zero if a*b < SCALING_FACTOR / 2
-     * @param a signed integer
-     * @param b signed integer
-     * @return mul of two signed integer
+     * @param a FixedPoint
+     * @param b FixedPoint
+     * @return mul of two fixed point
      */
-    function mul(int256 a, int256 b) internal pure returns (int256) {
-        return (a.mul(b)).add(SCALING_FACTOR / 2) / SCALING_FACTOR;
+    function mul(FixedPointInt memory a, FixedPointInt memory b) internal pure returns (FixedPointInt memory) {
+        return FixedPointInt((a.value.mul(b.value)).add(SCALING_FACTOR / 2) / SCALING_FACTOR);
     }
 
     /**
-     * @notice divide two signed integer
+     * @notice divide two FixedPoint
      * @dev rounds to zero if a*b < SCALING_FACTOR / 2
-     * @param a signed integer
-     * @param b signed integer
+     * @param a FixedPoint
+     * @param b FixedPoint
      * @return div of two signed integer
      */
-    function div(int256 a, int256 b) internal pure returns (int256) {
-        return (a.mul(SCALING_FACTOR)).add(b / 2) / b;
+    function div(FixedPointInt memory a, FixedPointInt memory b) internal pure returns (FixedPointInt memory) {
+        return FixedPointInt((a.value.mul(SCALING_FACTOR)).add(b.value / 2) / b.value);
     }
 
     /**
@@ -85,8 +74,8 @@ library FixedPointInt256 {
      * @param b signed integer
      * @return min of two signed integer
      */
-    function min(int256 a, int256 b) internal pure returns (int256) {
-        return a < b ? a : b;
+    function min(FixedPointInt memory a, FixedPointInt memory b) internal pure returns (FixedPointInt memory) {
+        return a.value < b.value ? a : b;
     }
 
     /**
@@ -95,8 +84,8 @@ library FixedPointInt256 {
      * @param b signed integer
      * @return max of two signed integer
      */
-    function max(int256 a, int256 b) internal pure returns (int256) {
-        return a > b ? a : b;
+    function max(FixedPointInt memory a, FixedPointInt memory b) internal pure returns (FixedPointInt memory) {
+        return a.value > b.value ? a : b;
     }
 
     /**
@@ -105,8 +94,8 @@ library FixedPointInt256 {
      * @param b a signed integer
      * @return True if equal, or False.
      */
-    function isEqual(int256 a, int256 b) internal pure returns (bool) {
-        return a == b;
+    function isEqual(FixedPointInt memory a, FixedPointInt memory b) internal pure returns (bool) {
+        return a.value == b.value;
     }
 
     /**
@@ -115,8 +104,8 @@ library FixedPointInt256 {
      * @param b a signed integer
      * @return True if `a > b`, or False.
      */
-    function isGreaterThan(int256 a, int256 b) internal pure returns (bool) {
-        return a > b;
+    function isGreaterThan(FixedPointInt memory a, FixedPointInt memory b) internal pure returns (bool) {
+        return a.value > b.value;
     }
 
     /**
@@ -125,8 +114,8 @@ library FixedPointInt256 {
      * @param b a signed integer
      * @return True if `a >= b`, or False.
      */
-    function isGreaterThanOrEqual(int256 a, int256 b) internal pure returns (bool) {
-        return a >= b;
+    function isGreaterThanOrEqual(FixedPointInt memory a, FixedPointInt memory b) internal pure returns (bool) {
+        return a.value >= b.value;
     }
 
     /**
@@ -135,17 +124,17 @@ library FixedPointInt256 {
      * @param b a signed integer
      * @return True if `a < b`, or False.
      */
-    function isLessThan(int256 a, int256 b) internal pure returns (bool) {
-        return a < b;
+    function isLessThan(FixedPointInt memory a, FixedPointInt memory b) internal pure returns (bool) {
+        return a.value < b.value;
     }
 
     /**
      * @notice Whether `a` is less than or equal to `b`.
-     * @param a a signed integer
+     * @param a a Fixed
      * @param b a signed integer
      * @return True if `a <= b`, or False.
      */
-    function isLessThanOrEqual(int256 a, int256 b) internal pure returns (bool) {
-        return a <= b;
+    function isLessThanOrEqual(FixedPointInt memory a, FixedPointInt memory b) internal pure returns (bool) {
+        return a.value <= b.value;
     }
 }

--- a/contracts/libs/SignedConverter.sol
+++ b/contracts/libs/SignedConverter.sol
@@ -1,0 +1,33 @@
+/**
+ * SPDX-License-Identifier: UNLICENSED
+ */
+pragma solidity 0.6.10;
+
+/**
+ *
+ */
+library SignedConverter {
+    /**
+     * @notice convert an unsigned integer to signed integer
+     * @param a uint to convert into a signed integer.
+     * @return the converted signed integer.
+     */
+    function uintToInt(uint256 a) internal pure returns (int256) {
+        require(a < uint256(-1), "FixedPointInt256: out of int range");
+
+        return int256(a);
+    }
+
+    /**
+     * @notice convert a signed integer to unsigned integer
+     * @param a int to convert into an unsigned integer.
+     * @return the converted unsigned integer.
+     */
+    function intToUint(int256 a) internal pure returns (uint256) {
+        if (a < 0) {
+            return uint256(-a);
+        } else {
+            return uint256(a);
+        }
+    }
+}

--- a/contracts/tests/FixedPointInt256Tester.sol
+++ b/contracts/tests/FixedPointInt256Tester.sol
@@ -3,6 +3,8 @@
  */
 pragma solidity 0.6.10;
 
+pragma experimental ABIEncoderV2;
+
 import "../libs/FixedPointInt256.sol";
 
 /**
@@ -10,55 +12,104 @@ import "../libs/FixedPointInt256.sol";
  * @notice FixedPointInt256 contract tester
  */
 contract FixedPointInt256Tester {
-    function testFromInt(int256 a) external pure returns (uint256) {
+    using FixedPointInt256 for FixedPointInt256.FixedPointInt;
+
+    /*function testFromInt(int256 a) external pure returns (uint256) {
         return FixedPointInt256.intToUint(a);
     }
 
     function testFromUint(uint256 a) external pure returns (int256) {
         return FixedPointInt256.uintToInt(a);
+    }*/
+    function testFromUnscaledInt(int256 a) external pure returns (FixedPointInt256.FixedPointInt memory) {
+        return FixedPointInt256.fromUnscaledInt(a);
     }
 
-    function testAdd(int256 a, int256 b) external pure returns (int256) {
+    function testAdd(FixedPointInt256.FixedPointInt memory a, FixedPointInt256.FixedPointInt memory b)
+        external
+        pure
+        returns (FixedPointInt256.FixedPointInt memory)
+    {
         return FixedPointInt256.add(a, b);
     }
 
-    function testSub(int256 a, int256 b) external pure returns (int256) {
+    function testSub(FixedPointInt256.FixedPointInt memory a, FixedPointInt256.FixedPointInt memory b)
+        external
+        pure
+        returns (FixedPointInt256.FixedPointInt memory)
+    {
         return FixedPointInt256.sub(a, b);
     }
 
-    function testMul(int256 a, int256 b) external pure returns (int256) {
+    function testMul(FixedPointInt256.FixedPointInt memory a, FixedPointInt256.FixedPointInt memory b)
+        external
+        pure
+        returns (FixedPointInt256.FixedPointInt memory)
+    {
         return FixedPointInt256.mul(a, b);
     }
 
-    function testDiv(int256 a, int256 b) external pure returns (int256) {
+    function testDiv(FixedPointInt256.FixedPointInt memory a, FixedPointInt256.FixedPointInt memory b)
+        external
+        pure
+        returns (FixedPointInt256.FixedPointInt memory)
+    {
         return FixedPointInt256.div(a, b);
     }
 
-    function testMin(int256 a, int256 b) external pure returns (int256) {
+    function testMin(FixedPointInt256.FixedPointInt memory a, FixedPointInt256.FixedPointInt memory b)
+        external
+        pure
+        returns (FixedPointInt256.FixedPointInt memory)
+    {
         return FixedPointInt256.min(a, b);
     }
 
-    function testMax(int256 a, int256 b) external pure returns (int256) {
+    function testMax(FixedPointInt256.FixedPointInt memory a, FixedPointInt256.FixedPointInt memory b)
+        external
+        pure
+        returns (FixedPointInt256.FixedPointInt memory)
+    {
         return FixedPointInt256.max(a, b);
     }
 
-    function testIsEqual(int256 a, int256 b) external pure returns (bool) {
+    function testIsEqual(FixedPointInt256.FixedPointInt memory a, FixedPointInt256.FixedPointInt memory b)
+        external
+        pure
+        returns (bool)
+    {
         return FixedPointInt256.isEqual(a, b);
     }
 
-    function testIsGreaterThan(int256 a, int256 b) external pure returns (bool) {
+    function testIsGreaterThan(FixedPointInt256.FixedPointInt memory a, FixedPointInt256.FixedPointInt memory b)
+        external
+        pure
+        returns (bool)
+    {
         return FixedPointInt256.isGreaterThan(a, b);
     }
 
-    function testIsGreaterThanOrEqual(int256 a, int256 b) external pure returns (bool) {
+    function testIsGreaterThanOrEqual(FixedPointInt256.FixedPointInt memory a, FixedPointInt256.FixedPointInt memory b)
+        external
+        pure
+        returns (bool)
+    {
         return FixedPointInt256.isGreaterThanOrEqual(a, b);
     }
 
-    function testIsLessThan(int256 a, int256 b) external pure returns (bool) {
+    function testIsLessThan(FixedPointInt256.FixedPointInt memory a, FixedPointInt256.FixedPointInt memory b)
+        external
+        pure
+        returns (bool)
+    {
         return FixedPointInt256.isLessThan(a, b);
     }
 
-    function testIsLessThanOrEqual(int256 a, int256 b) external pure returns (bool) {
+    function testIsLessThanOrEqual(FixedPointInt256.FixedPointInt memory a, FixedPointInt256.FixedPointInt memory b)
+        external
+        pure
+        returns (bool)
+    {
         return FixedPointInt256.isLessThanOrEqual(a, b);
     }
 }

--- a/contracts/tests/SignedConverterTester.sol
+++ b/contracts/tests/SignedConverterTester.sol
@@ -1,0 +1,25 @@
+/**
+ * SPDX-License-Identifier: UNLICENSED
+ */
+pragma solidity 0.6.10;
+
+pragma experimental ABIEncoderV2;
+
+import "../libs/SignedConverter.sol";
+
+/**
+ * @author Opyn Team
+ * @notice SignedConverter contract tester
+ */
+contract SignedConverterTester {
+    using SignedConverter for int256;
+    using SignedConverter for uint256;
+
+    function testFromInt(int256 a) external pure returns (uint256) {
+        return SignedConverter.intToUint(a);
+    }
+
+    function testFromUint(uint256 a) external pure returns (int256) {
+        return SignedConverter.uintToInt(a);
+    }
+}

--- a/test/fixedPointInt256.test.ts
+++ b/test/fixedPointInt256.test.ts
@@ -12,50 +12,10 @@ contract('FixedPointInt256 lib', () => {
     lib = await FixedPointInt256Tester.new()
   })
 
-  describe('Test type conversion', () => {
-    it('Should convert from unsigned integer to signed integer', async () => {
-      const uint = new BigNumber(5)
-      const expectedInt = new BigNumber(5)
-
-      assert.equal(
-        (await lib.testFromUint(uint)).toNumber(),
-        expectedInt.toNumber(),
-        'conversion from uint to int mismatch',
-      )
-    })
-
-    it('It should revert converting an unsigned integer greater than uint256(-1) to signed integer', async () => {
-      const uint = new BigNumber(2).multipliedBy(1e256).minus(1)
-
-      await expectRevert(lib.testFromUint(uint), 'FixedPointInt256: out of int range')
-    })
-
-    it('Should convert from signed integer to unsigned integer', async () => {
-      const int = new BigNumber(-3)
-      const expectedUint = new BigNumber(3)
-
-      assert.equal(
-        (await lib.testFromInt(int)).toNumber(),
-        expectedUint.toNumber(),
-        'conversion from int to uint mismatch',
-      )
-    })
-    it('Should convert from positive signed integer to unsigned integer', async () => {
-      const int = new BigNumber(3)
-      const expectedUint = new BigNumber(3)
-
-      assert.equal(
-        (await lib.testFromInt(int)).toNumber(),
-        expectedUint.toNumber(),
-        'conversion from int to uint mismatch',
-      )
-    })
-  })
-
   describe('Test Addition', () => {
     it('Should return 7e18 for 5e18 + 2e18', async () => {
-      const a = new BigNumber(5).multipliedBy(1e18)
-      const b = new BigNumber(2).multipliedBy(1e18)
+      const a = await lib.testFromUnscaledInt(new BigNumber(5))
+      const b = await lib.testFromUnscaledInt(new BigNumber(2))
       const expectedResult = new BigNumber(7).multipliedBy(1e18)
 
       assert.equal((await lib.testAdd(a, b)).toString(), expectedResult.toString(), 'adding result mismatch')
@@ -64,8 +24,8 @@ contract('FixedPointInt256 lib', () => {
 
   describe('Test subtraction', () => {
     it('Should return 2e18 for 7e18 - 5e18', async () => {
-      const a = new BigNumber(7).multipliedBy(1e18)
-      const b = new BigNumber(5).multipliedBy(1e18)
+      const a = await lib.testFromUnscaledInt(new BigNumber(7))
+      const b = await lib.testFromUnscaledInt(new BigNumber(5))
       const expectedResult = new BigNumber(2).multipliedBy(1e18)
 
       assert.equal((await lib.testSub(a, b)).toString(), expectedResult.toString(), 'subtraction result mismatch')
@@ -74,8 +34,8 @@ contract('FixedPointInt256 lib', () => {
 
   describe('Test mul', () => {
     it('Should return 10e18 for 2e18 * 5e18', async () => {
-      const a = new BigNumber(2).multipliedBy(1e18)
-      const b = new BigNumber(5).multipliedBy(1e18)
+      const a = await lib.testFromUnscaledInt(new BigNumber(2))
+      const b = await lib.testFromUnscaledInt(new BigNumber(5))
       const expectedResult = new BigNumber(10).multipliedBy(1e18)
 
       assert.equal((await lib.testMul(a, b)).toString(), expectedResult.toString(), 'multiplication result mismatch')
@@ -84,8 +44,8 @@ contract('FixedPointInt256 lib', () => {
 
   describe('Test div', () => {
     it('Should return 2e18 for 10e18 divided by 5e18', async () => {
-      const a = new BigNumber(10).multipliedBy(1e18)
-      const b = new BigNumber(5).multipliedBy(1e18)
+      const a = await lib.testFromUnscaledInt(new BigNumber(10))
+      const b = await lib.testFromUnscaledInt(new BigNumber(5))
       const expectedResult = new BigNumber(2).multipliedBy(1e18)
 
       assert.equal((await lib.testDiv(a, b)).toString(), expectedResult.toString(), 'division result mismatch')
@@ -94,16 +54,16 @@ contract('FixedPointInt256 lib', () => {
 
   describe('Test min', () => {
     it('Should return 3e18 between 3e18 and 5e18', async () => {
-      const a = new BigNumber(3).multipliedBy(1e18)
-      const b = new BigNumber(5).multipliedBy(1e18)
+      const a = await lib.testFromUnscaledInt(new BigNumber(3))
+      const b = await lib.testFromUnscaledInt(new BigNumber(5))
       const expectedResult = new BigNumber(3).multipliedBy(1e18)
 
       assert.equal((await lib.testMin(a, b)).toString(), expectedResult.toString(), 'minimum result mismatch')
     })
 
     it('Should return -2e18 between -2e18 and 2e18', async () => {
-      const a = new BigNumber(-2).multipliedBy(1e18)
-      const b = new BigNumber(2).multipliedBy(1e18)
+      const a = await lib.testFromUnscaledInt(new BigNumber(-2))
+      const b = await lib.testFromUnscaledInt(new BigNumber(-2))
       const expectedResult = new BigNumber(-2).multipliedBy(1e18)
 
       assert.equal((await lib.testMin(a, b)).toString(), expectedResult.toString(), 'minimum result mismatch')
@@ -112,8 +72,8 @@ contract('FixedPointInt256 lib', () => {
 
   describe('Test max', () => {
     it('Should return 3e18 between 3e18 and 1e18', async () => {
-      const a = new BigNumber(3).multipliedBy(1e18)
-      const b = new BigNumber(1).multipliedBy(1e18)
+      const a = await lib.testFromUnscaledInt(new BigNumber(3))
+      const b = await lib.testFromUnscaledInt(new BigNumber(1))
       const expectedResult = new BigNumber(3).multipliedBy(1e18)
 
       assert.equal((await lib.testMax(a, b)).toString(), expectedResult.toString(), 'maximum result mismatch')
@@ -122,41 +82,41 @@ contract('FixedPointInt256 lib', () => {
 
   describe('Test comparison operator', () => {
     it('Should return if two int are equal or not', async () => {
-      const a = new BigNumber(3).multipliedBy(1e18)
-      const b = new BigNumber(3).multipliedBy(1e18)
-      const expectedResult = a.isEqualTo(b)
+      const a = await lib.testFromUnscaledInt(new BigNumber(3))
+      const b = await lib.testFromUnscaledInt(new BigNumber(3))
+      const expectedResult = true
 
       assert.equal(await lib.testIsEqual(a, b), expectedResult, 'isEqual result mismatch')
     })
 
     it('Should return if a is greater than b or not', async () => {
-      const a = new BigNumber(-2).multipliedBy(1e18)
-      const b = new BigNumber(2).multipliedBy(1e18)
-      const expectedResult = a.isGreaterThan(b)
+      const a = await lib.testFromUnscaledInt(new BigNumber(-2))
+      const b = await lib.testFromUnscaledInt(new BigNumber(2))
+      const expectedResult = false
 
       assert.equal(await lib.testIsGreaterThan(a, b), expectedResult, 'isGreaterThan result mismatch')
     })
 
     it('Should return if a is greater than or equal b', async () => {
-      const a = new BigNumber(-2).multipliedBy(1e18)
-      const b = new BigNumber(-2).multipliedBy(1e18)
-      const expectedResult = a.isGreaterThanOrEqualTo(b)
+      const a = await lib.testFromUnscaledInt(new BigNumber(-2))
+      const b = await lib.testFromUnscaledInt(new BigNumber(-2))
+      const expectedResult = true
 
       assert.equal(await lib.testIsGreaterThanOrEqual(a, b), expectedResult, 'isGreaterThanOrEqual result mismatch')
     })
 
     it('Should return if a is less than b or not', async () => {
-      const a = new BigNumber(-2).multipliedBy(1e18)
-      const b = new BigNumber(0).multipliedBy(1e18)
-      const expectedResult = a.isLessThan(b)
+      const a = await lib.testFromUnscaledInt(new BigNumber(-2))
+      const b = await lib.testFromUnscaledInt(new BigNumber(0))
+      const expectedResult = true
 
       assert.equal(await lib.testIsLessThan(a, b), expectedResult, 'isLessThan result mismatch')
     })
 
     it('Should return if a is less than or equal b', async () => {
-      const a = new BigNumber(0).multipliedBy(1e18)
-      const b = new BigNumber(0).multipliedBy(1e18)
-      const expectedResult = a.isLessThanOrEqualTo(b)
+      const a = await lib.testFromUnscaledInt(new BigNumber(0))
+      const b = await lib.testFromUnscaledInt(new BigNumber(0))
+      const expectedResult = true
 
       assert.equal(await lib.testIsLessThanOrEqual(a, b), expectedResult, 'isLessThanOrEqual result mismatch')
     })

--- a/test/signedConverter.test.ts
+++ b/test/signedConverter.test.ts
@@ -1,0 +1,54 @@
+import {SignedConverterTesterInstance} from '../build/types/truffle-types'
+import BigNumber from 'bignumber.js'
+
+const {expectRevert} = require('@openzeppelin/test-helpers')
+
+const SignedConverterTester = artifacts.require('SignedConverterTester.sol')
+
+contract('FixedPointInt256 lib', () => {
+  let lib: SignedConverterTesterInstance
+
+  before('set up contracts', async () => {
+    lib = await SignedConverterTester.new()
+  })
+
+  describe('Test type conversion', () => {
+    it('Should convert from unsigned integer to signed integer', async () => {
+      const uint = new BigNumber(5)
+      const expectedInt = new BigNumber(5)
+
+      assert.equal(
+        (await lib.testFromUint(uint)).toNumber(),
+        expectedInt.toNumber(),
+        'conversion from uint to int mismatch',
+      )
+    })
+
+    it('It should revert converting an unsigned integer greater than uint256(-1) to signed integer', async () => {
+      const uint = new BigNumber(2).multipliedBy(1e256).minus(1)
+
+      await expectRevert(lib.testFromUint(uint), 'FixedPointInt256: out of int range')
+    })
+
+    it('Should convert from signed integer to unsigned integer', async () => {
+      const int = new BigNumber(-3)
+      const expectedUint = new BigNumber(3)
+
+      assert.equal(
+        (await lib.testFromInt(int)).toNumber(),
+        expectedUint.toNumber(),
+        'conversion from int to uint mismatch',
+      )
+    })
+    it('Should convert from positive signed integer to unsigned integer', async () => {
+      const int = new BigNumber(3)
+      const expectedUint = new BigNumber(3)
+
+      assert.equal(
+        (await lib.testFromInt(int)).toNumber(),
+        expectedUint.toNumber(),
+        'conversion from int to uint mismatch',
+      )
+    })
+  })
+})


### PR DESCRIPTION
# Update fixed point library

## High Level Description

- Update fixed point library to use struct to represent scaled number instead of a simple int variable
- Moved `uintToInt()` and `intToUint()` to a new `SignedConverter` library because they are not related to FixedPoint lib.

Closes #78 .

### Code

- [X] Unit test 100% coverage
- [X] Does your code follow the naming and code documentation guidelines?

### Documentation

- [X] Is your code up to date with the spec? 
- [X] Have you added your tests to the testing doc?
