### PR TITLE
Task/Consider collateral price in calculator

### DIFF
--- a/contracts/MarginCalculator.sol
+++ b/contracts/MarginCalculator.sol
@@ -71,7 +71,9 @@ contract MarginCalculator is Initializable {
         // Vault contains no short tokens: return collateral value.
         if (_isEmptyAssetArray(_vault.shortOtokens)) return (SignedConverter.intToUint(collateralAmount.value), true);
 
+        // get required margin, denominated in strike or underlying asset
         FixedPointInt256.FixedPointInt memory marginRequirement = _getMarginRequired(_vault);
+        // get exchange rate to convert marginRequirement to amount of collateral
         FixedPointInt256.FixedPointInt memory exchangeRate = _getToCollateralRate(_vault.shortOtokens[0]);
 
         // only multiplied by the exchange rate if it's not equal to 1, to avoid rounding problem.
@@ -83,7 +85,7 @@ contract MarginCalculator is Initializable {
 
         FixedPointInt256.FixedPointInt memory excessCollateral = collateralAmount.sub(collateralRequired);
         bool isExcess = excessCollateral.isGreaterThanOrEqual(_uint256ToFixedPointInt(0));
-        // uint256 excessCollateral = SignedConverter.intToUint(excessMargin.value);
+
         return (SignedConverter.intToUint(excessCollateral.value), isExcess);
     }
 

--- a/contracts/MarginCalculator.sol
+++ b/contracts/MarginCalculator.sol
@@ -93,7 +93,7 @@ contract MarginCalculator is Initializable {
         // The vault passed in has a short array == 1, so we can just use shortAmounts[0]
         FixedPointInt256.FixedPointInt memory shortAmount = _uint256ToFixedPointInt(_vault.shortAmounts[0]);
 
-        bool hasLongInVault = _vault.longOtokens.length > 0 && _vault.longOtokens[0] != address(0);
+        bool hasLongInVault = !_isEmptyAssetArray(_vault.longOtokens);
         FixedPointInt256.FixedPointInt memory longAmount = hasLongInVault
             ? _uint256ToFixedPointInt(_vault.longAmounts[0])
             : _uint256ToFixedPointInt(0);

--- a/contracts/MarginCalculator.sol
+++ b/contracts/MarginCalculator.sol
@@ -313,8 +313,8 @@ contract MarginCalculator is Initializable {
             address strike = short.strikeAsset();
             if (strike != collateral) {
                 // price is already scaled by 1e18
-                uint256 strikePrice = oracle.getPrice(strike); // 50 usdc
-                uint256 collateralPrice = oracle.getPrice(collateral); // 100 usdc
+                uint256 strikePrice = oracle.getPrice(strike);
+                uint256 collateralPrice = oracle.getPrice(collateral);
                 toCollateralExchangeRate = _uint256ToFixedPointInt(strikePrice).div(
                     _uint256ToFixedPointInt(collateralPrice)
                 );

--- a/contracts/interfaces/OracleInterface.sol
+++ b/contracts/interfaces/OracleInterface.sol
@@ -10,6 +10,8 @@ interface OracleInterface {
 
     function getPricer(address _asset) external view returns (address);
 
+    function getPrice(address _asset) external view returns (uint256);
+
     function getPricerLockingPeriod(address _pricer) external view returns (uint256);
 
     function getPricerDisputePeriod(address _pricer) external view returns (uint256);

--- a/contracts/tests/FixedPointInt256Tester.sol
+++ b/contracts/tests/FixedPointInt256Tester.sol
@@ -42,6 +42,15 @@ contract FixedPointInt256Tester {
         return a.mul(b);
     }
 
+    function testMulOne(FixedPointInt256.FixedPointInt memory a)
+        external
+        pure
+        returns (FixedPointInt256.FixedPointInt memory)
+    {
+        FixedPointInt256.FixedPointInt memory b = FixedPointInt256.fromUnscaledInt(1);
+        return a.mul(b);
+    }
+
     function testDiv(FixedPointInt256.FixedPointInt memory a, FixedPointInt256.FixedPointInt memory b)
         external
         pure

--- a/test/MarginAccount.test.ts
+++ b/test/MarginAccount.test.ts
@@ -59,6 +59,15 @@ contract('MarginAccount', ([deployer, controller]) => {
       assert.equal(vault.shortAmounts[vault.shortAmounts.length - 1], new BigNumber(10))
     })
 
+    it('should revert when adding 0 short', async () => {
+      const vaultCounter = new BigNumber(0)
+
+      await expectRevert(
+        marginAccountTester.testAddShort(vaultCounter, otoken.address, 0, 0),
+        'MarginAccount: invalid short otoken amount',
+      )
+    })
+
     it('should add a different short otokens to a different index', async () => {
       const vaultCounter = new BigNumber(0)
 

--- a/test/fixedPointInt256.test.ts
+++ b/test/fixedPointInt256.test.ts
@@ -45,6 +45,13 @@ contract('FixedPointInt256 lib', () => {
 
       assert.equal((await lib.testMul(a, b)).toString(), '0', 'multiplication result mismatch')
     })
+
+    it('Should return x for 1 * x', async () => {
+      const a = {value: '47619047619047618'}
+      // const b = await lib.testFromUnscaledInt(new BigNumber(1))
+
+      assert.equal((await lib.testMulOne(a)).toString(), a.value, 'multiplication result mismatch')
+    })
   })
 
   describe('Test div', () => {

--- a/test/marginCalculator.test.ts
+++ b/test/marginCalculator.test.ts
@@ -822,14 +822,14 @@ contract('MarginCalculator', () => {
         await oracle.setExpiryPrice(weth.address, expiry, createScaledNumber(210))
       })
 
-      it('(1) Short: 1 200 put, long 1 250 put => Net value', async () => {
+      it('(1) Short: 1 200 put, long 1 250 put => excess 40', async () => {
         const vault = createVault(eth200Put.address, eth250Put.address, usdc.address, amountOne, amountOne, '0')
         const [netValue, isExcess] = await calculator.getExcessCollateral(vault)
         assert.equal(isExcess, true)
         assert.equal(netValue.toString(), createScaledNumber(40))
       })
 
-      it('(2) Short: 1 250 put, long 1 200 put, collateral 50 USDC => Net value', async () => {
+      it('(2) Short: 1 250 put, long 1 200 put, collateral 50 USDC => excess 10', async () => {
         const vault = createVault(
           eth250Put.address,
           eth200Put.address,
@@ -1013,16 +1013,17 @@ contract('MarginCalculator', () => {
           await time.increaseTo(expiry + 2)
         }
         await oracle.setExpiryPrice(weth.address, expiry, createScaledNumber(210))
+        await oracle.setIsFinalized(weth.address, expiry, true)
       })
 
-      it('(1) Short: 1 250 call, long 1 200 call, collateral 0 USDC => Net value', async () => {
+      it('(1) Short: 1 250 call, long 1 200 call, collateral 0 USDC => excess 0.47 eth', async () => {
         const vault = createVault(eth250Call.address, eth200Call.address, weth.address, amountOne, amountOne, '0')
         const [netValue, isExcess] = await calculator.getExcessCollateral(vault)
         assert.equal(isExcess, true)
         assert.equal(netValue.toString(), '47619047619047618') // 0.47619047619047618
       })
 
-      it('(2) Short: 1 200 put, long 1 250 put, collateral 0.2 weth => Net value', async () => {
+      it('(2) Short: 1 200 put, long 1 250 put, collateral 0.2 weth => excess: 0.15 eth', async () => {
         const vault = createVault(
           eth200Call.address,
           eth250Call.address,

--- a/test/marginCalculator.test.ts
+++ b/test/marginCalculator.test.ts
@@ -319,7 +319,7 @@ contract('MarginCalculator', () => {
       })
 
       it('Should revert when collateral is different from collateral of short', async () => {
-        const vault = createVault(eth200Put.address, undefined, weth.address, createScaledNumber(1), undefined, 100)
+        const vault = createVault(eth200Put.address, undefined, weth.address, scaleNum(1), undefined, 100)
         await expectRevert(
           calculator.getExcessCollateral(vault),
           'MarginCalculator: collateral asset not marginable for short asset',

--- a/test/marginCalculator.test.ts
+++ b/test/marginCalculator.test.ts
@@ -21,17 +21,27 @@ contract('MarginCalculator', () => {
   let calculator: MarginCalculatorInstance
   let addressBook: MockAddressBookInstance
   let oracle: MockOracleInstance
+  // eth puts
   let eth300Put: MockOtokenInstance
   let eth250Put: MockOtokenInstance
   let eth200Put: MockOtokenInstance
   let eth100Put: MockOtokenInstance
+  // eth puts cUSDC collateral
+  let eth300PutCUSDC: MockOtokenInstance
+
+  // eth calls
   let eth300Call: MockOtokenInstance
   let eth250Call: MockOtokenInstance
   let eth200Call: MockOtokenInstance
   let eth100Call: MockOtokenInstance
+  // eth calls cETH collateral
+  let eth300CallCETH: MockOtokenInstance
+
   let usdc: MockERC20Instance
   let dai: MockERC20Instance
   let weth: MockERC20Instance
+  let ceth: MockERC20Instance
+  let cusdc: MockERC20Instance
 
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
@@ -48,24 +58,30 @@ contract('MarginCalculator', () => {
     usdc = await MockERC20.new('USDC', 'USDC')
     dai = await MockERC20.new('DAI', 'DAI')
     weth = await MockERC20.new('WETH', 'WETH')
+    cusdc = await MockERC20.new('cUSDC', 'cUSDC')
+    ceth = await MockERC20.new('cETH', 'cETH')
     // setup put tokens
     eth300Put = await MockOtoken.new()
     eth250Put = await MockOtoken.new()
     eth200Put = await MockOtoken.new()
     eth100Put = await MockOtoken.new()
+    eth300PutCUSDC = await MockOtoken.new()
     await eth300Put.init(weth.address, usdc.address, usdc.address, createScaledNumber(300), expiry, true)
     await eth250Put.init(weth.address, usdc.address, usdc.address, createScaledNumber(250), expiry, true)
     await eth200Put.init(weth.address, usdc.address, usdc.address, createScaledNumber(200), expiry, true)
     await eth100Put.init(weth.address, usdc.address, usdc.address, createScaledNumber(100), expiry, true)
+    await eth300PutCUSDC.init(weth.address, usdc.address, cusdc.address, createScaledNumber(300), expiry, true)
     // setup call tokens
     eth300Call = await MockOtoken.new()
     eth250Call = await MockOtoken.new()
     eth200Call = await MockOtoken.new()
     eth100Call = await MockOtoken.new()
+    eth300CallCETH = await MockOtoken.new()
     await eth300Call.init(weth.address, usdc.address, weth.address, createScaledNumber(300), expiry, false)
     await eth250Call.init(weth.address, usdc.address, weth.address, createScaledNumber(250), expiry, false)
     await eth200Call.init(weth.address, usdc.address, weth.address, createScaledNumber(200), expiry, false)
     await eth100Call.init(weth.address, usdc.address, weth.address, createScaledNumber(100), expiry, false)
+    await eth300CallCETH.init(weth.address, usdc.address, ceth.address, createScaledNumber(300), expiry, false)
   })
 
   describe('Get cash value tests', () => {


### PR DESCRIPTION
# Task: Update Calculator

## High Level Description

Add logic to deal with options that have different strike/ underlying than collateral.
Add one more function called `_getToCollateralRate` that deal with this conversion rate

### For put:
* conversion only happen when strike != collateral
* eg, underlying = ETH, strike = USDC, collateral = cUSDC
* in this case, the output of `_getMarginRequired` will be denominated in strike (USDC)
* the output of `_getToCollateralRate` will tell us 1 USDC = ? cUSDC. Let's say ? = 50
* assume output of `_getMarginRequired` is 50 USDC, the real required collateral is 2500 USD.

### For call 
* conversion only happen when underlying != collateral
* eg, underlying = ETH, strike = USDC, collateral = cETH
* in this case, the output of `_getMarginRequired` will be denominated in strike (ETH)
* the output of `_getToCollateralRate` will tell us 1 ETH = ? cETH. Let's say ? = 50
* assume output of `_getMarginRequired` is 1 ETH, the real required collateral is 50 cETH 
### Code

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?

### Documentation

- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
