### PR TITLE
Fix shadowed variable bug

### DIFF
--- a/contracts/Controller.sol
+++ b/contracts/Controller.sol
@@ -199,8 +199,8 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
      * @param _actions array of actions arguments
      */
     function operate(Actions.ActionArgs[] memory _actions) external nonReentrant {
-        (bool vaultUpdated, address owner, uint256 vaultId) = _runActions(_actions);
-        if (vaultUpdated) _verifyFinalState(owner, vaultId);
+        (bool vaultUpdated, address vaultOwner, uint256 vaultId) = _runActions(_actions);
+        if (vaultUpdated) _verifyFinalState(vaultOwner, vaultId);
     }
 
     /**


### PR DESCRIPTION
# Task: Feature Name:

Fix shadowed variable bug

## High Level Description

Rename `owner` variable to `vaultOwner` as `owner` was shadowed by the same variable name in Ownable contract

### Code

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?

### Documentation

- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
