### PR TITLE
Rename isExpired => hasExpired

### DIFF
--- a/contracts/Controller.sol
+++ b/contracts/Controller.sol
@@ -417,7 +417,7 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
      * @param _otoken oToken address
      * @return true if the otoken has expired, otherwise it returns false
      */
-    function isExpired(address _otoken) public view returns (bool) {
+    function hasExpired(address _otoken) external view returns (bool) {
         uint256 otokenExpiryTimestamp = OtokenInterface(_otoken).expiryTimestamp();
 
         return now > otokenExpiryTimestamp;

--- a/docs/contracts-documentation/Controller.md
+++ b/docs/contracts-documentation/Controller.md
@@ -52,7 +52,7 @@ contract that controls the gamma protocol and interaction with all sub contracts
 
 - `getAccountVaultCounter(address _accountOwner) (external)`
 
-- `isExpired(address _otoken) (public)`
+- `hasExpired(address _otoken) (public)`
 
 - `getVault(address _owner, uint256 _vaultId) (public)`
 
@@ -330,7 +330,7 @@ get the number of current vaults for a specified account owner
 
 - number of vaults
 
-### Function `isExpired(address _otoken) → bool public`
+### Function `hasExpired(address _otoken) → bool public`
 
 check if an oToken has expired
 

--- a/docs/uml/GammaController.svg
+++ b/docs/uml/GammaController.svg
@@ -90,7 +90,7 @@
 <text text-anchor="start" x="8" y="-75.9" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;&lt;&lt;modifier&gt;&gt; onlyAuthorized(_sender: address, _accountOwner: address)</text>
 <text text-anchor="start" x="8" y="-59.1" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;&lt;&lt;modifier&gt;&gt; onlyWhitelistedCallee(_callee: address)</text>
 <text text-anchor="start" x="8" y="-42.3" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;isSettlementAllowed(_otoken: address): bool</text>
-<text text-anchor="start" x="8" y="-25.5" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;isExpired(_otoken: address): bool</text>
+<text text-anchor="start" x="8" y="-25.5" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;hasExpired(_otoken: address): bool</text>
 <text text-anchor="start" x="8" y="-8.7" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;getVault(_owner: address, _vaultId: uint256): MarginVault.Vault</text>
 </g>
 </g>

--- a/docs/uml/GammaUML.svg
+++ b/docs/uml/GammaUML.svg
@@ -736,7 +736,7 @@
 <text text-anchor="start" x="2712.6503" y="-75.9" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;&lt;&lt;modifier&gt;&gt; onlyAuthorized(_sender: address, _accountOwner: address)</text>
 <text text-anchor="start" x="2712.6503" y="-59.1" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;&lt;&lt;modifier&gt;&gt; onlyWhitelistedCallee(_callee: address)</text>
 <text text-anchor="start" x="2712.6503" y="-42.3" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;isSettlementAllowed(_otoken: address): bool</text>
-<text text-anchor="start" x="2712.6503" y="-25.5" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;isExpired(_otoken: address): bool</text>
+<text text-anchor="start" x="2712.6503" y="-25.5" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;hasExpired(_otoken: address): bool</text>
 <text text-anchor="start" x="2712.6503" y="-8.7" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;getVault(_owner: address, _vaultId: uint256): MarginVault.Vault</text>
 </g>
 <!-- 1&#45;&gt;19 -->

--- a/test/unit-tests/controller.test.ts
+++ b/test/unit-tests/controller.test.ts
@@ -1090,7 +1090,7 @@ contract(
             ]
 
             assert.equal(
-              await controllerProxy.isExpired(expiredLongOtoken.address),
+              await controllerProxy.hasExpired(expiredLongOtoken.address),
               true,
               'Long otoken is not expired yet',
             )
@@ -2616,7 +2616,7 @@ contract(
             ]
 
             assert.equal(
-              await controllerProxy.isExpired(expiredShortOtoken.address),
+              await controllerProxy.hasExpired(expiredShortOtoken.address),
               true,
               'Long otoken is not expired yet',
             )
@@ -2766,7 +2766,7 @@ contract(
           },
         ]
 
-        assert.equal(await controllerProxy.isExpired(shortOtoken.address), false, 'Short otoken has already expired')
+        assert.equal(await controllerProxy.hasExpired(shortOtoken.address), false, 'Short otoken has already expired')
 
         await expectRevert(
           controllerProxy.operate(actionArgs, {from: holder1}),
@@ -2812,7 +2812,7 @@ contract(
           },
         ]
 
-        assert.equal(await controllerProxy.isExpired(shortOtoken.address), true, 'Short otoken is not expired yet')
+        assert.equal(await controllerProxy.hasExpired(shortOtoken.address), true, 'Short otoken is not expired yet')
 
         await expectRevert(
           controllerProxy.operate(actionArgs, {from: holder1}),
@@ -2842,7 +2842,7 @@ contract(
           },
         ]
 
-        assert.equal(await controllerProxy.isExpired(shortOtoken.address), true, 'Short otoken is not expired yet')
+        assert.equal(await controllerProxy.hasExpired(shortOtoken.address), true, 'Short otoken is not expired yet')
 
         await expectRevert(
           controllerProxy.operate(actionArgs, {from: holder1}),
@@ -2864,7 +2864,7 @@ contract(
             data: ZERO_ADDR,
           },
         ]
-        assert.equal(await controllerProxy.isExpired(shortOtoken.address), true, 'Short otoken is not expired yet')
+        assert.equal(await controllerProxy.hasExpired(shortOtoken.address), true, 'Short otoken is not expired yet')
 
         const payout = createTokenAmount(50, usdcDecimals)
         const marginPoolBalanceBefore = new BigNumber(await usdc.balanceOf(marginPool.address))
@@ -3411,7 +3411,7 @@ contract(
           },
         ]
 
-        assert.equal(await controllerProxy.isExpired(shortOtoken.address), true, 'Short otoken is not expired yet')
+        assert.equal(await controllerProxy.hasExpired(shortOtoken.address), true, 'Short otoken is not expired yet')
 
         await expectRevert(
           controllerProxy.operate(actionArgs, {from: accountOwner1}),
@@ -3837,7 +3837,7 @@ contract(
           true,
         )
 
-        assert.equal(await controllerProxy.isExpired(otoken.address), false, 'Otoken expiry check mismatch')
+        assert.equal(await controllerProxy.hasExpired(otoken.address), false, 'Otoken expiry check mismatch')
       })
 
       it('should return true for expired otoken', async () => {
@@ -3854,7 +3854,7 @@ contract(
           true,
         )
 
-        assert.equal(await controllerProxy.isExpired(expiredOtoken.address), true, 'Otoken expiry check mismatch')
+        assert.equal(await controllerProxy.hasExpired(expiredOtoken.address), true, 'Otoken expiry check mismatch')
       })
     })
 
@@ -4195,7 +4195,7 @@ contract(
             data: ZERO_ADDR,
           },
         ]
-        assert.equal(await controllerProxy.isExpired(shortOtoken.address), true, 'Short otoken is not expired yet')
+        assert.equal(await controllerProxy.hasExpired(shortOtoken.address), true, 'Short otoken is not expired yet')
 
         const payout = createTokenAmount(50, usdcDecimals)
         const marginPoolBalanceBefore = new BigNumber(await usdc.balanceOf(marginPool.address))

--- a/test/unit-tests/payableProxyController.test.ts
+++ b/test/unit-tests/payableProxyController.test.ts
@@ -426,7 +426,7 @@ contract('PayableProxyController', ([owner, accountOwner1, holder1, random]) => 
           data: ZERO_ADDR,
         },
       ]
-      assert.equal(await controllerProxy.isExpired(shortOtoken.address), true, 'Short otoken is not expired yet')
+      assert.equal(await controllerProxy.hasExpired(shortOtoken.address), true, 'Short otoken is not expired yet')
 
       await shortOtoken.transfer(payableProxyController.address, amountToRedeem.toString(), {from: holder1})
       await payableProxyController.operate(actionArgs, holder1, {from: holder1})


### PR DESCRIPTION
# Task: Rename isExpired

rename the function `isExpired` to `hasExpired` as suggested in the master doc

### Todos
- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?
- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
