### PR TITLE
Update event parameter name in SystemPaused

### DIFF
--- a/contracts/Controller.sol
+++ b/contracts/Controller.sol
@@ -136,9 +136,9 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
     /// @notice emits an event when the partialPauser address changes
     event PartialPauserUpdated(address indexed oldPartialPauser, address indexed newPartialPauser);
     /// @notice emits an event when the system partial paused status changes
-    event SystemPartiallyPaused(bool isActive);
+    event SystemPartiallyPaused(bool isPaused);
     /// @notice emits an event when the system fully paused status changes
-    event SystemFullyPaused(bool isActive);
+    event SystemFullyPaused(bool isPaused);
     /// @notice emits an event when the call action restriction changes
     event CallRestricted(bool isRestricted);
 


### PR DESCRIPTION
# Task: Update event parameter name

We have the `isActive` parameter in our events `SystemPartiallyPaused` and `SystemFullyPaused` 
```javascript
Event SystemPartiallyPaused {
    bool isActive 
}
```
but when we want to set the system to `paused`, we emit the event with `SystemPartiallyPaused(_paused)`. Which is confusing. We should just rename the parameter from `isActive` to `isPaused`

### Todos
- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?
- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
