### PR TITLE
Certora: fix rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ coverage.json
 gasReporterOutput.json
 .secret
 .infuraKey
+specs/.certora_config
+specs/.last_confs
+specs/.certora_build.json
+specs/.certora_verify

--- a/contracts/libs/MarginVault.sol
+++ b/contracts/libs/MarginVault.sol
@@ -51,13 +51,17 @@ library MarginVault {
 
         // valid indexes in any array are between 0 and array.length - 1.
         // if adding an amount to an preexisting short oToken, check that _index is in the range of 0->length-1
-        if ((_index == _vault.shortOtokens.length) && ((_index == _vault.shortAmounts.length))) {
+        if ((_index == _vault.shortOtokens.length) && (_index == _vault.shortAmounts.length)) {
             _vault.shortOtokens.push(_shortOtoken);
             _vault.shortAmounts.push(_amount);
         } else {
             require(
+                (_index == _vault.shortOtokens.length) && (_index == _vault.shortAmounts.length),
+                "MarginVault: invalid short otoken index"
+            );
+            require(
                 (_vault.shortOtokens[_index] == _shortOtoken) || (_vault.shortOtokens[_index] == address(0)),
-                "MarginVault: invalid short otoken position"
+                "MarginVault: short otoken address mismatch"
             );
 
             _vault.shortAmounts[_index] = _vault.shortAmounts[_index].add(_amount);
@@ -108,13 +112,17 @@ library MarginVault {
 
         // valid indexes in any array are between 0 and array.length - 1.
         // if adding an amount to an preexisting short oToken, check that _index is in the range of 0->length-1
-        if ((_index == _vault.longOtokens.length) && ((_index == _vault.longAmounts.length))) {
+        if ((_index == _vault.longOtokens.length) && (_index == _vault.longAmounts.length)) {
             _vault.longOtokens.push(_longOtoken);
             _vault.longAmounts.push(_amount);
         } else {
             require(
+                (_index == _vault.longOtokens.length) && (_index == _vault.longAmounts.length),
+                "MarginVault: invalid long otoken index"
+            );
+            require(
                 (_vault.longOtokens[_index] == _longOtoken) || (_vault.longOtokens[_index] == address(0)),
-                "MarginVault: invalid long otoken position"
+                "MarginVault: long otoken address mismatch"
             );
 
             _vault.longAmounts[_index] = _vault.longAmounts[_index].add(_amount);
@@ -165,14 +173,18 @@ library MarginVault {
 
         // valid indexes in any array are between 0 and array.length - 1.
         // if adding an amount to an preexisting short oToken, check that _index is in the range of 0->length-1
-        if ((_index == _vault.collateralAssets.length) && ((_index == _vault.collateralAmounts.length))) {
+        if ((_index == _vault.collateralAssets.length) && (_index == _vault.collateralAmounts.length)) {
             _vault.collateralAssets.push(_collateralAsset);
             _vault.collateralAmounts.push(_amount);
         } else {
             require(
+                (_index < _vault.collateralAssets.length) && (_index < _vault.collateralAmounts.length),
+                "MarginVault: invalid collateral token index"
+            );
+            require(
                 (_vault.collateralAssets[_index] == _collateralAsset) ||
                     (_vault.collateralAssets[_index] == address(0)),
-                "MarginVault: invalid collateral token position"
+                "MarginVault: collateral token address mismatch"
             );
 
             _vault.collateralAmounts[_index] = _vault.collateralAmounts[_index].add(_amount);

--- a/contracts/libs/MarginVault.sol
+++ b/contracts/libs/MarginVault.sol
@@ -108,7 +108,7 @@ library MarginVault {
 
         // valid indexes in any array are between 0 and array.length - 1.
         // if adding an amount to an preexisting short oToken, check that _index is in the range of 0->length-1
-        if ((_index >= _vault.longOtokens.length) && ((_index >= _vault.longAmounts.length))) {
+        if ((_index == _vault.longOtokens.length) && ((_index == _vault.longAmounts.length))) {
             _vault.longOtokens.push(_longOtoken);
             _vault.longAmounts.push(_amount);
         } else {
@@ -165,7 +165,7 @@ library MarginVault {
 
         // valid indexes in any array are between 0 and array.length - 1.
         // if adding an amount to an preexisting short oToken, check that _index is in the range of 0->length-1
-        if ((_index >= _vault.collateralAssets.length) && ((_index >= _vault.collateralAmounts.length))) {
+        if ((_index == _vault.collateralAssets.length) && ((_index == _vault.collateralAmounts.length))) {
             _vault.collateralAssets.push(_collateralAsset);
             _vault.collateralAmounts.push(_amount);
         } else {

--- a/contracts/libs/MarginVault.sol
+++ b/contracts/libs/MarginVault.sol
@@ -56,7 +56,7 @@ library MarginVault {
             _vault.shortAmounts.push(_amount);
         } else {
             require(
-                (_index == _vault.shortOtokens.length) && (_index == _vault.shortAmounts.length),
+                (_index < _vault.shortOtokens.length) && (_index < _vault.shortAmounts.length),
                 "MarginVault: invalid short otoken index"
             );
             require(
@@ -117,7 +117,7 @@ library MarginVault {
             _vault.longAmounts.push(_amount);
         } else {
             require(
-                (_index == _vault.longOtokens.length) && (_index == _vault.longAmounts.length),
+                (_index < _vault.longOtokens.length) && (_index < _vault.longAmounts.length),
                 "MarginVault: invalid long otoken index"
             );
             require(

--- a/contracts/libs/MarginVault.sol
+++ b/contracts/libs/MarginVault.sol
@@ -51,7 +51,7 @@ library MarginVault {
 
         // valid indexes in any array are between 0 and array.length - 1.
         // if adding an amount to an preexisting short oToken, check that _index is in the range of 0->length-1
-        if ((_index >= _vault.shortOtokens.length) && ((_index >= _vault.shortAmounts.length))) {
+        if ((_index == _vault.shortOtokens.length) && ((_index == _vault.shortAmounts.length))) {
             _vault.shortOtokens.push(_shortOtoken);
             _vault.shortAmounts.push(_amount);
         } else {

--- a/specs/MarginVault.spec
+++ b/specs/MarginVault.spec
@@ -116,7 +116,7 @@ rule integrityOfAddCollateral(address asset, uint256 x, uint256 index)
 rule additiveAddCollateral(address asset, uint256 x, uint256 y, uint256 index)
 {
 		requireInvariant validVault();
-    	// require index < MAXINT(); // no violation when limiting index
+    	require index < MAXINT(); // no violation when limiting index
     	require x > 0 && y > 0 ;
     	uint256 t = x + y ;
         require( t >= x && t >= y); //no overflow
@@ -167,7 +167,7 @@ rule integrityOfAddShort(address shortOtoken, uint256 x, uint256 index)
 rule additiveAddShort(address shortOtoken, uint256 x, uint256 y, uint256 index)
 {
 	requireInvariant validVault();
-	// require index < MAXINT(); // no violation when limiting index
+	require index < MAXINT(); // no violation when limiting index
 	require x > 0 && y > 0 ;
 	uint256 t = x + y ;
     require( t >= x && t >= y); //no overflow
@@ -215,7 +215,7 @@ rule integrityOfAddLong(address longOtoken, uint256 x, uint256 index)
 rule additiveAddLong(address longOtoken, uint256 x, uint256 y, uint256 index)
 {
 	requireInvariant validVault();
-	// require index < MAXINT(); // no violation when limiting index
+	require index < MAXINT(); // no violation when limiting index
 	require x > 0 && y > 0 ;
 	uint256 t = x + y ;
     require( t >= x && t >= y); //no overflow

--- a/specs/MarginVault.spec
+++ b/specs/MarginVault.spec
@@ -28,7 +28,7 @@ methods {
 }
 
 definition MAXINT() returns uint256 = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
-definition ADDRESSZERO() return address = address(0);
+definition ADDRESSZERO() return address = 0;
 
 /**
 @title Valid state of a vault

--- a/specs/MarginVault.spec
+++ b/specs/MarginVault.spec
@@ -83,6 +83,7 @@ rule successOfAddCollateral(address asset, uint256 x, uint256 index)
 	requireInvariant validVault();
 	require x > 0;
 	require index < MAXINT();
+	require index <= collateralAmountLength();
 	if (index < collateralAmountLength()) {
 		require asset == getCollateralAsset(index);
 		require getCollateralAmount(index) + x < MAXINT();

--- a/specs/MarginVault.spec
+++ b/specs/MarginVault.spec
@@ -83,13 +83,22 @@ rule successOfAddCollateral(address asset, uint256 x, uint256 index)
 	requireInvariant validVault();
 	require x > 0;
 	require index < MAXINT();
-	require index <= collateralAmountLength();
+	// require index <= collateralAmountLength();
 	if (index < collateralAmountLength()) {
 		require asset == getCollateralAsset(index);
 		require getCollateralAmount(index) + x < MAXINT();
+
+		invoke addCollateral(asset, x, index);
+		assert !lastReverted, "addCollateral may revert when precondition holds";
 	}
-	invoke addCollateral(asset, x, index);
-	assert !lastReverted, "addCollateral may revert when precondition holds";
+	else if ((index == collateralAmountLength())) {
+		invoke addCollateral(asset, x, index);
+		assert !lastReverted, "addCollateral may revert when precondition holds";
+	}
+	else {
+		invoke addCollateral(asset, x, index);
+		assert lastReverted, "addCollateral may not revert when precondition not holds";
+	}
 }
 
 

--- a/specs/MarginVault.spec
+++ b/specs/MarginVault.spec
@@ -28,6 +28,7 @@ methods {
 }
 
 definition MAXINT() returns uint256 = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+definition ADDRESSZERO() return address = address(0);
 
 /**
 @title Valid state of a vault
@@ -81,6 +82,7 @@ rule changeToOneEntity(uint256 shortIndex, uint256 longIndex, uint256 collateral
 rule successOfAddCollateral(address asset, uint256 x, uint256 index)
 {
 	requireInvariant validVault();
+	require asset != ADDRESSZERO();
 	require x > 0;
 	require index < MAXINT();
 	// require index <= collateralAmountLength();
@@ -112,6 +114,7 @@ rule successOfAddCollateral(address asset, uint256 x, uint256 index)
 rule integrityOfAddCollateral(address asset, uint256 x, uint256 index)
 {
 	requireInvariant validVault();
+	require asset != ADDRESSZERO();
 	uint256 collateralBefore = totalCollateral();
 	sinvoke addCollateral(asset, x, index);
 	assert totalCollateral() == collateralBefore + x, "integirty break of addCollateral";
@@ -126,6 +129,7 @@ rule integrityOfAddCollateral(address asset, uint256 x, uint256 index)
 rule additiveAddCollateral(address asset, uint256 x, uint256 y, uint256 index)
 {
 		requireInvariant validVault();
+		require asset != ADDRESSZERO();
     	require index < MAXINT(); // no violation when limiting index
     	require x > 0 && y > 0 ;
     	uint256 t = x + y ;
@@ -165,6 +169,7 @@ rule inverseAddRemoveCollateral(address asset, uint256 x, uint256 index)
 rule integrityOfAddShort(address shortOtoken, uint256 x, uint256 index)
 {
 	requireInvariant validVault();
+	require asset != ADDRESSZERO();
 	uint256 shortAmountBefore = totalShortAmount();
 	sinvoke addShort(shortOtoken, x, index);
 	assert  totalShortAmount() == shortAmountBefore + x &&
@@ -177,6 +182,7 @@ rule integrityOfAddShort(address shortOtoken, uint256 x, uint256 index)
 rule additiveAddShort(address shortOtoken, uint256 x, uint256 y, uint256 index)
 {
 	requireInvariant validVault();
+	require asset != ADDRESSZERO();
 	require index < MAXINT(); // no violation when limiting index
 	require x > 0 && y > 0 ;
 	uint256 t = x + y ;
@@ -213,6 +219,7 @@ rule inverseAddRemoveShort(address shortOtoken, uint256 x, uint256 index)
 rule integrityOfAddLong(address longOtoken, uint256 x, uint256 index)
 {
 	requireInvariant validVault();
+	require asset != ADDRESSZERO();
 	uint256 longAmountBefore = totalLongAmount();
 	sinvoke addLong(longOtoken, x, index);
 	assert totalLongAmount() == longAmountBefore + x &&
@@ -225,6 +232,7 @@ rule integrityOfAddLong(address longOtoken, uint256 x, uint256 index)
 rule additiveAddLong(address longOtoken, uint256 x, uint256 y, uint256 index)
 {
 	requireInvariant validVault();
+	require asset != ADDRESSZERO();
 	require index < MAXINT(); // no violation when limiting index
 	require x > 0 && y > 0 ;
 	uint256 t = x + y ;

--- a/test/unit-tests/marginVault.test.ts
+++ b/test/unit-tests/marginVault.test.ts
@@ -276,7 +276,7 @@ contract('MarginVault', ([deployer, controller]) => {
       const vaultCounter = new BigNumber(0)
 
       await expectRevert(
-        marginVaultTester.testAddLong(vaultCounter, weth.address, 10, 4),
+        marginVaultTester.testAddCollateral(vaultCounter, weth.address, 10, 4),
         'MarginVault: invalid collateral token index',
       )
     })

--- a/test/unit-tests/marginVault.test.ts
+++ b/test/unit-tests/marginVault.test.ts
@@ -55,6 +55,15 @@ contract('MarginVault', ([deployer, controller]) => {
   })
 
   describe('Add short', async () => {
+    it('should revert if trying to add short otoken with index greater than short otoken array length', async () => {
+      const vaultCounter = new BigNumber(0)
+
+      await expectRevert(
+        marginVaultTester.testAddShort(vaultCounter, otoken.address, 10, 4),
+        'MarginVault: invalid short otoken index',
+      )
+    })
+
     it('should add short otokens', async () => {
       const vaultCounter = new BigNumber(0)
 
@@ -157,6 +166,15 @@ contract('MarginVault', ([deployer, controller]) => {
   })
 
   describe('Add long', () => {
+    it('should revert if trying to add long otoken with index greater than long otoken array length', async () => {
+      const vaultCounter = new BigNumber(0)
+
+      await expectRevert(
+        marginVaultTester.testAddLong(vaultCounter, otoken.address, 10, 4),
+        'MarginVault: invalid long otoken index',
+      )
+    })
+
     it('should add long otokens', async () => {
       const index = 0
       const amount = 10
@@ -254,6 +272,15 @@ contract('MarginVault', ([deployer, controller]) => {
   })
 
   describe('Add collateral', () => {
+    it('should revert if trying to add collateral asset with index greater than collateral asset array length', async () => {
+      const vaultCounter = new BigNumber(0)
+
+      await expectRevert(
+        marginVaultTester.testAddLong(vaultCounter, weth.address, 10, 4),
+        'MarginVault: invalid collateral token index',
+      )
+    })
+
     it('should add weth collateral', async () => {
       const index = 0
       const amount = 10

--- a/test/unit-tests/marginVault.test.ts
+++ b/test/unit-tests/marginVault.test.ts
@@ -88,12 +88,12 @@ contract('MarginVault', ([deployer, controller]) => {
       assert.equal(vault.shortAmounts[vault.shortAmounts.length - 1], new BigNumber(23))
     })
 
-    it('should revert if trying to add wrong otoken to an index', async () => {
+    it('should revert if trying to add wrong short otoken to an index', async () => {
       const vaultCounter = new BigNumber(0)
 
       await expectRevert(
         marginVaultTester.testAddShort(vaultCounter, otoken.address, 10, 1),
-        'MarginVault: invalid short otoken position',
+        'MarginVault: short otoken address mismatch',
       )
     })
   })
@@ -187,14 +187,14 @@ contract('MarginVault', ([deployer, controller]) => {
       assert.equal(vault.longAmounts[index], new BigNumber(20))
     })
 
-    it('should revert if trying to add wrong otoken to an index', async () => {
+    it('should revert if trying to add wrong long otoken to an index', async () => {
       const index = 1
       const amount = 10
       const vaultCounter = new BigNumber(0)
 
       await expectRevert(
         marginVaultTester.testAddLong(vaultCounter, otoken.address, amount, index),
-        'MarginVault: invalid long otoken position',
+        'MarginVault: long otoken address mismatch',
       )
     })
   })
@@ -298,7 +298,7 @@ contract('MarginVault', ([deployer, controller]) => {
 
       await expectRevert(
         marginVaultTester.testAddCollateral(vaultCounter, usdc.address, changeAmt, index),
-        'MarginVault: invalid collateral token position',
+        'MarginVault: collateral token address mismatch',
       )
     })
 
@@ -326,7 +326,7 @@ contract('MarginVault', ([deployer, controller]) => {
 
       await expectRevert(
         marginVaultTester.testAddCollateral(vaultCounter, otoken.address, changeAmt, index),
-        'MarginVault: invalid collateral token position',
+        'MarginVault: collateral token address mismatch',
       )
     })
   })


### PR DESCRIPTION
# Certora: fix rules

## High Level Description

This PR:
- Update `addShort()`, `addLong()` and `addCollateral()` to pass the inverse rules. The new implementations will revert if the parameter index is not coherent with the array's length.
- Fix the additive rules
- Fix validEntityIndex 

### Code

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?

### Documentation

- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
