### PR TITLE
Add oToken field to VaultSettled event

### DIFF
--- a/contracts/Controller.sol
+++ b/contracts/Controller.sol
@@ -122,7 +122,13 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
         uint256 payout
     );
     /// @notice emits an event when a vault is settled
-    event VaultSettled(address indexed AccountOwner, address indexed to, uint256 vaultId, uint256 payout);
+    event VaultSettled(
+        address indexed AccountOwner,
+        address indexed to,
+        address indexed otoken,
+        uint256 vaultId,
+        uint256 payout
+    );
     /// @notice emits an event when a call action is executed
     event CallExecuted(
         address indexed from,
@@ -730,7 +736,10 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
 
         MarginVault.Vault memory vault = getVault(_args.owner, _args.vaultId);
 
-        require(_isNotEmpty(vault.shortOtokens) || _isNotEmpty(vault.longOtokens), "Can't settle vault with no otoken");
+        require(
+            _isNotEmpty(vault.shortOtokens) || _isNotEmpty(vault.longOtokens),
+            "Controller: Can't settle vault with no otoken"
+        );
 
         OtokenInterface otoken = _isNotEmpty(vault.shortOtokens)
             ? OtokenInterface(vault.shortOtokens[0])
@@ -751,7 +760,7 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
 
         pool.transferToUser(otoken.collateralAsset(), _args.to, payout);
 
-        emit VaultSettled(_args.owner, _args.to, _args.vaultId, payout);
+        emit VaultSettled(_args.owner, _args.to, address(otoken), _args.vaultId, payout);
     }
 
     /**

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -46,7 +46,7 @@ contract Oracle is Ownable {
     /// @notice emits an event when an expiry price is updated for a specific asset
     event ExpiryPriceUpdated(
         address indexed asset,
-        uint256 indexed expirtyTimestamp,
+        uint256 indexed expiryTimestamp,
         uint256 price,
         uint256 onchainTimestamp
     );

--- a/test/unit-tests/controller.test.ts
+++ b/test/unit-tests/controller.test.ts
@@ -3317,7 +3317,7 @@ contract(
 
         await expectRevert(
           controllerProxy.operate(actionArgs, {from: accountOwner1}),
-          "Can't settle vault with no otoken",
+          "Controller: Can't settle vault with no otoken",
         )
       })
 


### PR DESCRIPTION
# Task: Update VaultSettle Event
## High Level Description

* Add otoken field for VaultSettle event so the graph can know what position the user is closing.
* Add the `Controller:` prefix to revert message `Can't settle vault with no otoken`

### Todos

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?
- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
