### PR TITLE
[L02] Constants are not being declared explicitly

### DIFF
--- a/contracts/MarginCalculator.sol
+++ b/contracts/MarginCalculator.sol
@@ -23,7 +23,10 @@ contract MarginCalculator {
 
     address public addressBook;
 
+    /// @dev decimals used by strike price and oracle price
     uint256 internal constant BASE = 8;
+
+    /// @dev FixedPoint 0
     FPI.FixedPointInt internal ZERO = FPI.fromScaledUint(0, BASE);
 
     constructor(address _addressBook) public {

--- a/contracts/OtokenFactory.sol
+++ b/contracts/OtokenFactory.sol
@@ -25,6 +25,9 @@ contract OtokenFactory is OtokenSpawner {
     /// @dev mapping from parameters hash to its deployed address
     mapping(bytes32 => address) private idToAddress;
 
+    /// @dev max expiry that BokkyPooBahsDateTimeLibrary can handle. (2345/12/31)
+    uint256 private MAX_EXPIRY = 11865398400;
+
     constructor(address _addressBook) public {
         addressBook = _addressBook;
     }
@@ -61,7 +64,8 @@ contract OtokenFactory is OtokenSpawner {
         bool _isPut
     ) external returns (address) {
         require(_expiry > now, "OtokenFactory: Can't create expired option");
-        require(_expiry < 11865398400, "OtokenFactory: Can't create option with expiry > 2345/12/31");
+        require(_expiry < MAX_EXPIRY, "OtokenFactory: Can't create option with expiry > 2345/12/31");
+        // 8 Hour in sec: 3600 * 8 = 28800
         require(_expiry.sub(28800).mod(86400) == 0, "OtokenFactory: Option has to expire 08:00 UTC");
         bytes32 id = _getOptionId(_underlyingAsset, _strikeAsset, _collateralAsset, _strikePrice, _expiry, _isPut);
         require(idToAddress[id] == address(0), "OtokenFactory: Option already created");

--- a/contracts/OtokenFactory.sol
+++ b/contracts/OtokenFactory.sol
@@ -65,7 +65,7 @@ contract OtokenFactory is OtokenSpawner {
     ) external returns (address) {
         require(_expiry > now, "OtokenFactory: Can't create expired option");
         require(_expiry < MAX_EXPIRY, "OtokenFactory: Can't create option with expiry > 2345/12/31");
-        // 8 Hour in sec: 3600 * 8 = 28800
+        // 8 hours = 3600 * 8 = 28800 seconds
         require(_expiry.sub(28800).mod(86400) == 0, "OtokenFactory: Option has to expire 08:00 UTC");
         bytes32 id = _getOptionId(_underlyingAsset, _strikeAsset, _collateralAsset, _strikePrice, _expiry, _isPut);
         require(idToAddress[id] == address(0), "OtokenFactory: Option already created");

--- a/contracts/OtokenFactory.sol
+++ b/contracts/OtokenFactory.sol
@@ -26,7 +26,7 @@ contract OtokenFactory is OtokenSpawner {
     mapping(bytes32 => address) private idToAddress;
 
     /// @dev max expiry that BokkyPooBahsDateTimeLibrary can handle. (2345/12/31)
-    uint256 private MAX_EXPIRY = 11865398400;
+    uint256 private constant MAX_EXPIRY = 11865398400;
 
     constructor(address _addressBook) public {
         addressBook = _addressBook;


### PR DESCRIPTION
# Task: Fix L02:

There are several occurrences of literal values with unexplained meaning. This PR added the followings:
1. Define a constant `MAX_EXPIRY ` instead of hardcoding `require(_expiry < 11865398400)`
2. Add comment to explain the UTC 08:00 constraint 

Feel free to push commits to this PR if there're other hardcoded number that would better be defined as constant.

### Todos

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?
- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
