### PR TITLE
[L07] Mismatches between contracts and interfaces

### DIFF
--- a/contracts/interfaces/MarginCalculatorInterface.sol
+++ b/contracts/interfaces/MarginCalculatorInterface.sol
@@ -6,9 +6,11 @@ pragma experimental ABIEncoderV2;
 import {MarginVault} from "../libs/MarginVault.sol";
 
 interface MarginCalculatorInterface {
+    function addressBook() external view returns (uint256);
+
     function getExpiredPayoutRate(address _otoken) external view returns (uint256);
 
-    function getExcessCollateral(MarginVault.Vault memory _vault)
+    function getExcessCollateral(MarginVault.Vault calldata _vault)
         external
         view
         returns (uint256 netValue, bool isExcess);

--- a/contracts/interfaces/MarginCalculatorInterface.sol
+++ b/contracts/interfaces/MarginCalculatorInterface.sol
@@ -6,7 +6,7 @@ pragma experimental ABIEncoderV2;
 import {MarginVault} from "../libs/MarginVault.sol";
 
 interface MarginCalculatorInterface {
-    function addressBook() external view returns (uint256);
+    function addressBook() external view returns (address);
 
     function getExpiredPayoutRate(address _otoken) external view returns (uint256);
 

--- a/contracts/interfaces/MarginPoolInterface.sol
+++ b/contracts/interfaces/MarginPoolInterface.sol
@@ -2,6 +2,23 @@
 pragma solidity 0.6.10;
 
 interface MarginPoolInterface {
+    /* Getters */
+    function addressBook() external view returns (address);
+
+    function farmer() external view returns (address);
+
+    function getStoredBalance(address _asset) external view returns (uint256);
+
+    /* Admin-only functions */
+    function setFarmer(address _farmer) external;
+
+    function farm(
+        address _asset,
+        address _receiver,
+        uint256 _amount
+    ) external;
+
+    /* Controller-only functions */
     function transferToPool(
         address _asset,
         address _user,
@@ -14,13 +31,13 @@ interface MarginPoolInterface {
         uint256 _amount
     ) external;
 
-    function transferToPool(
+    function batchTransferToPool(
         address[] calldata _asset,
         address[] calldata _user,
         uint256[] calldata _amount
     ) external;
 
-    function transferToUser(
+    function batchTransferToUser(
         address[] calldata _asset,
         address[] calldata _user,
         uint256[] calldata _amount

--- a/contracts/interfaces/OracleInterface.sol
+++ b/contracts/interfaces/OracleInterface.sol
@@ -8,6 +8,8 @@ interface OracleInterface {
 
     function getExpiryPrice(address _asset, uint256 _expiryTimestamp) external view returns (uint256, bool);
 
+    function getDisputer() external view returns (address);
+
     function getPricer(address _asset) external view returns (address);
 
     function getPrice(address _asset) external view returns (uint256);
@@ -35,4 +37,6 @@ interface OracleInterface {
         uint256 _expiryTimestamp,
         uint256 _price
     ) external;
+
+    function setDisputer(address _disputer) external;
 }

--- a/contracts/interfaces/OtokenInterface.sol
+++ b/contracts/interfaces/OtokenInterface.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.6.10;
 
 interface OtokenInterface {
-    function addressBook() external view returns (uint256);
+    function addressBook() external view returns (address);
 
     function underlyingAsset() external view returns (address);
 

--- a/contracts/interfaces/OtokenInterface.sol
+++ b/contracts/interfaces/OtokenInterface.sol
@@ -2,6 +2,8 @@
 pragma solidity 0.6.10;
 
 interface OtokenInterface {
+    function addressBook() external view returns (uint256);
+
     function underlyingAsset() external view returns (address);
 
     function strikeAsset() external view returns (address);

--- a/contracts/interfaces/WhitelistInterface.sol
+++ b/contracts/interfaces/WhitelistInterface.sol
@@ -3,6 +3,9 @@ pragma solidity 0.6.10;
 
 interface WhitelistInterface {
     /* View functions */
+
+    function addressBook() external view returns (address);
+
     function isWhitelistedProduct(
         address _underlying,
         address _strike,
@@ -14,6 +17,8 @@ interface WhitelistInterface {
 
     function isWhitelistedOtoken(address _otoken) external view returns (bool);
 
+    function isWhitelistedCallee(address _callee) external view returns (bool);
+
     /* Admin / factory only functions */
     function whitelistProduct(
         address _underlying,
@@ -22,9 +27,22 @@ interface WhitelistInterface {
         bool _isPut
     ) external;
 
+    function blacklistProduct(
+        address _underlying,
+        address _strike,
+        address _collateral,
+        bool _isPut
+    ) external;
+
     function whitelistCollateral(address _collateral) external;
+
+    function blacklistCollateral(address _collateral) external;
 
     function whitelistOtoken(address _otoken) external;
 
-    function isWhitelistedCallee(address _callee) external view returns (bool);
+    function blacklistOtoken(address _otoken) external;
+
+    function whitelistCallee(address _callee) external;
+
+    function blacklistCallee(address _callee) external;
 }


### PR DESCRIPTION
# Task: Fix L07

## Description
* The `OracleInterface` interface is missing the getDisputer and the setDisputer function.
* The `WhitelistInterface` interface is missing the addressBook getter, the blacklistProduct, blacklistCollateral, blacklistOtoken, whitelisteCallee, and blacklistCallee functions.
* The `OtokenInterface` interface is missing the addressBook getter.
* The `MarginPoolInterface` interface is missing the addressBook and farmer getters, and the getStoredBalance, farm, and setFarmer functions. Also, it have a mismatch between the name of the implemented batchTransferToPool and batchTransferToUser functions and the ones in the interface.
* The `MarginCalculatorInterface` interface should use calldata instead of memory due to the explicit use of the external visibility in interfaces, and it is missing the addressBook getter.

### Todos

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?
- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
