### PR TITLE
[L03] Operations are not explicitly casted

### DIFF
--- a/contracts/MarginCalculator.sol
+++ b/contracts/MarginCalculator.sol
@@ -87,7 +87,7 @@ contract MarginCalculator {
 
         FPI.FixedPointInt memory collateralAmount = ZERO;
         if (hasCollateral) {
-            uint256 colllateralDecimals = ERC20Interface(_vault.collateralAssets[0]).decimals();
+            uint256 colllateralDecimals = uint256(ERC20Interface(_vault.collateralAssets[0]).decimals());
             collateralAmount = FPI.fromScaledUint(_vault.collateralAmounts[0], colllateralDecimals);
         }
 
@@ -98,7 +98,7 @@ contract MarginCalculator {
         bool isExcess = excessCollateral.isGreaterThanOrEqual(ZERO);
 
         address otoken = hasLong ? _vault.longOtokens[0] : _vault.shortOtokens[0];
-        uint256 collateralDecimals = ERC20Interface(OtokenInterface(otoken).collateralAsset()).decimals();
+        uint256 collateralDecimals = uint256(ERC20Interface(OtokenInterface(otoken).collateralAsset()).decimals());
         // if is excess, truncate the tailing digits in excessCollateralExternal calculation
         uint256 excessCollateralExternal = excessCollateral.toScaledUint(collateralDecimals, isExcess);
         return (excessCollateralExternal, isExcess);

--- a/contracts/OtokenSpawner.sol
+++ b/contracts/OtokenSpawner.sol
@@ -15,7 +15,7 @@ import {Create2} from "./packages/oz/Create2.sol";
  */
 contract OtokenSpawner {
     // fixed salt value because we will only deploy an oToken with the same init value once
-    bytes32 private constant SALT = 0;
+    bytes32 private constant SALT = bytes32(0);
 
     /**
      * @notice internal function for spawning an eip-1167 minimal proxy using `CREATE2`

--- a/contracts/pricers/CompoundPricer.sol
+++ b/contracts/pricers/CompoundPricer.sol
@@ -78,8 +78,8 @@ contract CompoundPricer is OpynPricerInterface {
      * @return price of 1e8 cToken in USD, scaled by 1e8
      */
     function _underlyingPriceToCtokenPrice(uint256 _underlyingPrice) internal view returns (uint256) {
-        uint256 underlyingDecimals = underlying.decimals();
-        uint256 cTokenDecimals = cToken.decimals();
+        uint256 underlyingDecimals = uint256(underlying.decimals());
+        uint256 cTokenDecimals = uint256(cToken.decimals());
         uint256 exchangeRate = cToken.exchangeRateStored();
         return exchangeRate.mul(_underlyingPrice).mul(10**(cTokenDecimals)).div(10**(underlyingDecimals.add(18)));
     }


### PR DESCRIPTION
# Task: Fix L03

* Explicitly cast number to bytes in `OtokenSpawner`
* Explicitly cast decimals(uint8) to uint256

### Todos
- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?
- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
