### PR TITLE
[L05] Lack of input validation could pollute the event logs

### DIFF
--- a/contracts/Controller.sol
+++ b/contracts/Controller.sol
@@ -283,6 +283,7 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
      */
     function setFullPauser(address _fullPauser) external onlyOwner {
         require(_fullPauser != address(0), "Controller: fullPauser cannot be set to address zero");
+        require(fullPauser != _fullPauser, "Controller: invalid input");
 
         emit FullPauserUpdated(fullPauser, _fullPauser);
 
@@ -296,6 +297,7 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
      */
     function setPartialPauser(address _partialPauser) external onlyOwner {
         require(_partialPauser != address(0), "Controller: partialPauser cannot be set to address zero");
+        require(partialPauser != _partialPauser, "Controller: invalid input");
 
         emit PartialPauserUpdated(partialPauser, _partialPauser);
 

--- a/contracts/Controller.sol
+++ b/contracts/Controller.sol
@@ -256,6 +256,8 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
      * @param _partiallyPaused new boolean value to set systemPartiallyPaused to
      */
     function setSystemPartiallyPaused(bool _partiallyPaused) external onlyPartialPauser {
+        require(systemPartiallyPaused != _partiallyPaused, "Controller: invalid input");
+
         systemPartiallyPaused = _partiallyPaused;
 
         emit SystemPartiallyPaused(systemPartiallyPaused);
@@ -267,6 +269,8 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
      * @param _fullyPaused new boolean value to set systemFullyPaused to
      */
     function setSystemFullyPaused(bool _fullyPaused) external onlyFullPauser {
+        require(systemFullyPaused != _fullyPaused, "Controller: invalid input");
+
         systemFullyPaused = _fullyPaused;
 
         emit SystemFullyPaused(systemFullyPaused);
@@ -305,6 +309,8 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
      * @param _isRestricted new call restriction state
      */
     function setCallRestriction(bool _isRestricted) external onlyOwner {
+        require(callRestricted != _isRestricted, "Controller: invalid input");
+
         callRestricted = _isRestricted;
 
         emit CallRestricted(callRestricted);
@@ -317,6 +323,8 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
      * @param _isOperator new boolean value that expresses if the sender is giving or revoking privileges for _operator
      */
     function setOperator(address _operator, bool _isOperator) external {
+        require(operators[msg.sender][_operator] != _isOperator, "Controller: invalid input");
+
         operators[msg.sender][_operator] = _isOperator;
 
         emit AccountOperatorUpdated(msg.sender, _operator, _isOperator);

--- a/test/unit-tests/controller.test.ts
+++ b/test/unit-tests/controller.test.ts
@@ -3892,10 +3892,18 @@ contract(
         await expectRevert(controllerProxy.setCallRestriction(true, {from: random}), 'Ownable: caller is not the owner')
       })
 
+      it('should revert deactivating call action restriction when it is already deactivated', async () => {
+        await expectRevert(controllerProxy.setCallRestriction(false, {from: owner}), 'Controller: invalid input')
+      })
+
       it('should activate call action restriction from owner', async () => {
         await controllerProxy.setCallRestriction(true, {from: owner})
 
         assert.equal(await controllerProxy.callRestricted(), true, 'Call action restriction activation failed')
+      })
+
+      it('should revert activating call action restriction when it is already activated', async () => {
+        await expectRevert(controllerProxy.setCallRestriction(true, {from: owner}), 'Controller: invalid input')
       })
 
       it('should revert calling any arbitrary address when call restriction is activated', async () => {
@@ -4030,6 +4038,13 @@ contract(
         )
       })
 
+      it('should revert partially un-pausing an already running paused system', async () => {
+        await expectRevert(
+          controllerProxy.setSystemPartiallyPaused(false, {from: partialPauser}),
+          'Controller: invalid input',
+        )
+      })
+
       it('should pause system', async () => {
         const stateBefore = await controllerProxy.systemPartiallyPaused()
         assert.equal(stateBefore, false, 'System already paused')
@@ -4038,6 +4053,13 @@ contract(
 
         const stateAfter = await controllerProxy.systemPartiallyPaused()
         assert.equal(stateAfter, true, 'System not paused')
+      })
+
+      it('should revert partially pausing an already patially paused system', async () => {
+        await expectRevert(
+          controllerProxy.setSystemPartiallyPaused(true, {from: partialPauser}),
+          'Controller: invalid input',
+        )
       })
 
       it('should revert opening a vault when system is partially paused', async () => {
@@ -4335,6 +4357,10 @@ contract(
         )
       })
 
+      it('should revert fully un-pausing an already running system', async () => {
+        await expectRevert(controllerProxy.setSystemFullyPaused(false, {from: fullPauser}), 'Controller: invalid input')
+      })
+
       it('should trigger full pause', async () => {
         const stateBefore = await controllerProxy.systemFullyPaused()
         assert.equal(stateBefore, false, 'System already in full pause state')
@@ -4343,6 +4369,10 @@ contract(
 
         const stateAfter = await controllerProxy.systemFullyPaused()
         assert.equal(stateAfter, true, 'System not in full pause state')
+      })
+
+      it('should revert fully pausing an already fully paused system', async () => {
+        await expectRevert(controllerProxy.setSystemFullyPaused(true, {from: fullPauser}), 'Controller: invalid input')
       })
 
       it('should revert opening a vault when system is in full pause state', async () => {

--- a/test/unit-tests/controller.test.ts
+++ b/test/unit-tests/controller.test.ts
@@ -4045,6 +4045,13 @@ contract(
         assert.equal(await controllerProxy.partialPauser(), partialPauser, 'partialPauser address mismatch')
       })
 
+      it('should revert set partialPauser address to the same previous address', async () => {
+        await expectRevert(
+          controllerProxy.setPartialPauser(await controllerProxy.partialPauser(), {from: owner}),
+          'Controller: invalid input',
+        )
+      })
+
       it('should revert when pausing the system from address other than partialPauser', async () => {
         await expectRevert(
           controllerProxy.setSystemPartiallyPaused(true, {from: random}),
@@ -4362,6 +4369,13 @@ contract(
       it('should set fullPauser address', async () => {
         await controllerProxy.setFullPauser(fullPauser, {from: owner})
         assert.equal(await controllerProxy.fullPauser(), fullPauser, 'fullPauser address mismatch')
+      })
+
+      it('should revert set fullPauser address to the same previous address', async () => {
+        await expectRevert(
+          controllerProxy.setFullPauser(await controllerProxy.fullPauser(), {from: owner}),
+          'Controller: invalid input',
+        )
       })
 
       it('should revert when triggering full pause from address other than fullPauser', async () => {

--- a/test/unit-tests/controller.test.ts
+++ b/test/unit-tests/controller.test.ts
@@ -158,6 +158,13 @@ contract(
         )
       })
 
+      it('should revert when set an already operator', async () => {
+        await expectRevert(
+          controllerProxy.setOperator(accountOperator1, true, {from: accountOwner1}),
+          'Controller: invalid input',
+        )
+      })
+
       it('should be able to remove operator', async () => {
         await controllerProxy.setOperator(accountOperator1, false, {from: accountOwner1})
 
@@ -165,6 +172,13 @@ contract(
           await controllerProxy.isOperator(accountOwner1, accountOperator1),
           false,
           'Operator address mismatch',
+        )
+      })
+
+      it('should revert when removing an already removed operator', async () => {
+        await expectRevert(
+          controllerProxy.setOperator(accountOperator1, false, {from: accountOwner1}),
+          'Controller: invalid input',
         )
       })
     })


### PR DESCRIPTION
# Fix [L05] Lack of input validation could pollute the event logs

## High Level Description

This PR add input validation in the following functions, to check if the previous state is different than the target state before changing storage/emit events.

- setSystemPartiallyPaused
- setSystemFullyPaused
- setCallRestriction
- setOperator
- setFullPauser
- setPartialPauser

### Code

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?

### Documentation

- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
