### PR TITLE
[L01] Disputer can dispute a price before a pricer has submitted a price

### DIFF
--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -221,8 +221,12 @@ contract Oracle is Ownable {
         require(!isDisputePeriodOver(_asset, _expiryTimestamp), "Oracle: dispute period over");
 
         Price storage priceToUpdate = storedPrice[_asset][_expiryTimestamp];
+
+        require(priceToUpdate.timestamp != 0, "Oracle: price to dispute does not exist");
+
         uint256 oldPrice = priceToUpdate.price;
         priceToUpdate.price = _price;
+        priceToUpdate.timestamp = now;
 
         emit ExpiryPriceDisputed(_asset, _expiryTimestamp, oldPrice, _price, now);
     }

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -226,7 +226,6 @@ contract Oracle is Ownable {
 
         uint256 oldPrice = priceToUpdate.price;
         priceToUpdate.price = _price;
-        priceToUpdate.timestamp = now;
 
         emit ExpiryPriceDisputed(_asset, _expiryTimestamp, oldPrice, _price, now);
     }

--- a/test/unit-tests/oracle.test.ts
+++ b/test/unit-tests/oracle.test.ts
@@ -222,6 +222,13 @@ contract('Oracle', ([owner, disputer, random, collateral, strike]) => {
       )
     })
 
+    it('should revert disputing price before it get pushed by pricer', async () => {
+      await expectRevert(
+        oracle.disputeExpiryPrice(weth.address, otokenExpiry.plus(10), disputePrice, {from: disputer}),
+        'Oracle: price to dispute does not exist',
+      )
+    })
+
     it('should dispute price during dispute period', async () => {
       await oracle.disputeExpiryPrice(weth.address, otokenExpiry, disputePrice, {from: disputer})
 


### PR DESCRIPTION
# [L01] Disputer can dispute a price before a pricer has submitted a price

## High Level Description

This PR update the dispute price function to:
- allow disputing only when the price of that certain asset at a specific time is already submitted by the pricer.
- update price submission timestamp to be equal dispute timestamp.

### Code

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?

### Documentation

- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
