### PR TITLE
[L10] String is used as hash key

### DIFF
--- a/contracts/AddressBook.sol
+++ b/contracts/AddressBook.sol
@@ -12,21 +12,21 @@ import {OwnedUpgradeabilityProxy} from "./packages/oz/upgradeability/OwnedUpgrad
  */
 contract AddressBook is Ownable {
     /// @dev Otoken implementation key
-    bytes32 private constant OTOKEN_IMPL = "OTOKEN_IMPL";
+    bytes32 public constant OTOKEN_IMPL = keccak256("OTOKEN_IMPL");
     /// @dev OtokenFactory key
-    bytes32 private constant OTOKEN_FACTORY = "OTOKEN_FACTORY";
+    bytes32 private constant OTOKEN_FACTORY = keccak256("OTOKEN_FACTORY");
     /// @dev Whitelist key
-    bytes32 private constant WHITELIST = "WHITELIST";
+    bytes32 private constant WHITELIST = keccak256("WHITELIST");
     /// @dev Controller key
-    bytes32 private constant CONTROLLER = "CONTROLLER";
+    bytes32 private constant CONTROLLER = keccak256("CONTROLLER");
     /// @dev MarginPool key
-    bytes32 private constant MARGIN_POOL = "MARGIN_POOL";
+    bytes32 private constant MARGIN_POOL = keccak256("MARGIN_POOL");
     /// @dev MarginCalculator key
-    bytes32 private constant MARGIN_CALCULATOR = "MARGIN_CALCULATOR";
+    bytes32 private constant MARGIN_CALCULATOR = keccak256("MARGIN_CALCULATOR");
     /// @dev LiquidationManager key
-    bytes32 private constant LIQUIDATION_MANAGER = "LIQUIDATION_MANAGER";
+    bytes32 private constant LIQUIDATION_MANAGER = keccak256("LIQUIDATION_MANAGER");
     /// @dev Oracle key
-    bytes32 private constant ORACLE = "ORACLE";
+    bytes32 private constant ORACLE = keccak256("ORACLE");
 
     /// @dev mapping between key and address
     mapping(bytes32 => address) private addresses;

--- a/contracts/AddressBook.sol
+++ b/contracts/AddressBook.sol
@@ -12,7 +12,7 @@ import {OwnedUpgradeabilityProxy} from "./packages/oz/upgradeability/OwnedUpgrad
  */
 contract AddressBook is Ownable {
     /// @dev Otoken implementation key
-    bytes32 public constant OTOKEN_IMPL = keccak256("OTOKEN_IMPL");
+    bytes32 private constant OTOKEN_IMPL = keccak256("OTOKEN_IMPL");
     /// @dev OtokenFactory key
     bytes32 private constant OTOKEN_FACTORY = keccak256("OTOKEN_FACTORY");
     /// @dev Whitelist key

--- a/test/unit-tests/addressBook.test.ts
+++ b/test/unit-tests/addressBook.test.ts
@@ -198,7 +198,7 @@ contract('AddressBook', ([owner, otokenImplAdd, marginPoolAdd, liquidationManage
   })
 
   describe('Set arbitrary address', () => {
-    const modulekey = web3.utils.fromAscii('newModule')
+    const modulekey = web3.utils.soliditySha3('newModule')
     let module: UpgradeableContractV1Instance
 
     before(async () => {
@@ -225,7 +225,7 @@ contract('AddressBook', ([owner, otokenImplAdd, marginPoolAdd, liquidationManage
   })
 
   describe('Upgrade contract', async () => {
-    const key = web3.utils.fromAscii('ammModule')
+    const key = web3.utils.soliditySha3('ammModule')
 
     let v1Contract: UpgradeableContractV1Instance
     let v2Contract: UpgradeableContractV2Instance


### PR DESCRIPTION
# [L10] String is used as hash key

## High Level Description

This PR update the AddressBook modules key to use a hashed version of the string instead of directly casting the string itself to bytes32.

### Code

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?

### Documentation

- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
