### PR TITLE
[L09] oToken symbols might not be unique

### DIFF
--- a/contracts/Otoken.sol
+++ b/contracts/Otoken.sol
@@ -139,12 +139,13 @@ contract Otoken is ERC20Initializable {
             )
         );
 
-        // concatenated symbol string: oETHUSDCUSDC-05SEP20-200P
+        // concatenated symbol string: oETHUSDC/USDC-05SEP20-200P
         tokenSymbol = string(
             abi.encodePacked(
                 "o",
                 underlying,
                 strike,
+                "/",
                 collateral,
                 "-",
                 _uintTo2Chars(day),

--- a/contracts/Otoken.sol
+++ b/contracts/Otoken.sol
@@ -139,12 +139,13 @@ contract Otoken is ERC20Initializable {
             )
         );
 
-        // concatenated symbol string: oETHUSDC-05SEP20-200P
+        // concatenated symbol string: oETHUSDCUSDC-05SEP20-200P
         tokenSymbol = string(
             abi.encodePacked(
                 "o",
                 underlying,
                 strike,
+                collateral,
                 "-",
                 _uintTo2Chars(day),
                 monthSymbol,

--- a/test/integration-tests/open-markets.test.ts
+++ b/test/integration-tests/open-markets.test.ts
@@ -136,7 +136,7 @@ contract('OTokenFactory + Otoken: Cloning of real otoken instances.', ([owner, u
       })
       otoken1 = await Otoken.at(targetAddress1)
       assert.isTrue((await otoken1.name()).includes('200Put USDC Collateral'))
-      assert.isTrue((await otoken1.symbol()).includes('oWETHUSDCUSDC-'))
+      assert.isTrue((await otoken1.symbol()).includes('oWETHUSDC/USDC-'))
     })
 
     it('Should init otoken2 with correct name and symbol', async () => {

--- a/test/integration-tests/open-markets.test.ts
+++ b/test/integration-tests/open-markets.test.ts
@@ -136,7 +136,7 @@ contract('OTokenFactory + Otoken: Cloning of real otoken instances.', ([owner, u
       })
       otoken1 = await Otoken.at(targetAddress1)
       assert.isTrue((await otoken1.name()).includes('200Put USDC Collateral'))
-      assert.isTrue((await otoken1.symbol()).includes('oWETHUSDC-'))
+      assert.isTrue((await otoken1.symbol()).includes('oWETHUSDCUSDC-'))
     })
 
     it('Should init otoken2 with correct name and symbol', async () => {

--- a/test/unit-tests/Otoken.test.ts
+++ b/test/unit-tests/Otoken.test.ts
@@ -46,7 +46,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
 
     it('should initilized the put option with valid name / symbol', async () => {
       assert.equal(await otoken.name(), `WETHUSDC 25-September-2020 200Put USDC Collateral`)
-      assert.equal(await otoken.symbol(), `oWETHUSDCUSDC-25SEP20-200P`)
+      assert.equal(await otoken.symbol(), `oWETHUSDC/USDC-25SEP20-200P`)
       assert.equal((await otoken.decimals()).toNumber(), 8)
     })
 
@@ -70,7 +70,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await callOption.name(), `WETHUSDC 25-September-2020 200Call WETH Collateral`)
-      assert.equal(await callOption.symbol(), `oWETHUSDCWETH-25SEP20-200C`)
+      assert.equal(await callOption.symbol(), `oWETHUSDC/WETH-25SEP20-200C`)
     })
 
     it('should set the right name and symbol for option with strikePrice < 1', async () => {
@@ -81,7 +81,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await o1.name(), `WETHUSDC 25-September-2020 0.5Put USDC Collateral`)
-      assert.equal(await o1.symbol(), `oWETHUSDCUSDC-25SEP20-0.5P`)
+      assert.equal(await o1.symbol(), `oWETHUSDC/USDC-25SEP20-0.5P`)
     })
 
     it('should set the right name and symbol for option with strikePrice < 1, with 8 decimals', async () => {
@@ -92,7 +92,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await o2.name(), `WETHUSDC 25-September-2020 0.00010052Put USDC Collateral`)
-      assert.equal(await o2.symbol(), `oWETHUSDCUSDC-25SEP20-0.00010052P`)
+      assert.equal(await o2.symbol(), `oWETHUSDC/USDC-25SEP20-0.00010052P`)
     })
 
     it('should set the right name and symbol for option with strikePrice < 1, with starting and trailing zeroes.', async () => {
@@ -102,7 +102,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await o3.name(), `WETHUSDC 25-September-2020 0.0729Put USDC Collateral`)
-      assert.equal(await o3.symbol(), `oWETHUSDCUSDC-25SEP20-0.0729P`)
+      assert.equal(await o3.symbol(), `oWETHUSDC/USDC-25SEP20-0.0729P`)
     })
 
     it('should set the right name for option with strikePrice 0', async () => {
@@ -112,7 +112,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await oToken.name(), `WETHUSDC 25-September-2020 0Put USDC Collateral`)
-      assert.equal(await oToken.symbol(), `oWETHUSDCUSDC-25SEP20-0P`)
+      assert.equal(await oToken.symbol(), `oWETHUSDC/USDC-25SEP20-0P`)
     })
 
     it('should set the right name for non-eth options', async () => {
@@ -122,7 +122,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await putOption.name(), `WETHUSDC 25-September-2020 200Put USDC Collateral`)
-      assert.equal(await putOption.symbol(), `oWETHUSDCUSDC-25SEP20-200P`)
+      assert.equal(await putOption.symbol(), `oWETHUSDC/USDC-25SEP20-200P`)
     })
 
     it('should revert when init asset with non-erc20 address', async () => {
@@ -141,7 +141,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await otoken.name(), `WETHUSDC 01-January-1970 200Put USDC Collateral`)
-      assert.equal(await otoken.symbol(), `oWETHUSDCUSDC-01JAN70-200P`)
+      assert.equal(await otoken.symbol(), `oWETHUSDC/USDC-01JAN70-200P`)
     })
 
     it('should set the right name for options expiry on 2345/12/31', async () => {
@@ -152,7 +152,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await otoken.name(), `WETHUSDC 31-December-2345 200Put USDC Collateral`)
-      assert.equal(await otoken.symbol(), `oWETHUSDCUSDC-31DEC45-200P`)
+      assert.equal(await otoken.symbol(), `oWETHUSDC/USDC-31DEC45-200P`)
     })
 
     it('should set the right symbol for year 220x ', async () => {
@@ -161,7 +161,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
       await otoken.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, expiry, true, {
         from: deployer,
       })
-      assert.equal(await otoken.symbol(), 'oWETHUSDCUSDC-29JUL09-200P')
+      assert.equal(await otoken.symbol(), 'oWETHUSDC/USDC-29JUL09-200P')
       assert.equal(await otoken.name(), 'WETHUSDC 29-July-2209 200Put USDC Collateral')
     })
 
@@ -172,84 +172,84 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await January.name(), 'WETHUSDC 01-January-2030 200Put USDC Collateral')
-      assert.equal(await January.symbol(), 'oWETHUSDCUSDC-01JAN30-200P')
+      assert.equal(await January.symbol(), 'oWETHUSDC/USDC-01JAN30-200P')
 
       const February = await Otoken.new()
       await February.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1896134400, isPut, {
         from: deployer,
       })
       assert.equal(await February.name(), 'WETHUSDC 01-February-2030 200Put USDC Collateral')
-      assert.equal(await February.symbol(), 'oWETHUSDCUSDC-01FEB30-200P')
+      assert.equal(await February.symbol(), 'oWETHUSDC/USDC-01FEB30-200P')
 
       const March = await Otoken.new()
       await March.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1898553600, isPut, {
         from: deployer,
       })
       assert.equal(await March.name(), 'WETHUSDC 01-March-2030 200Put USDC Collateral')
-      assert.equal(await March.symbol(), 'oWETHUSDCUSDC-01MAR30-200P')
+      assert.equal(await March.symbol(), 'oWETHUSDC/USDC-01MAR30-200P')
 
       const April = await Otoken.new()
       await April.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1901232000, isPut, {
         from: deployer,
       })
       assert.equal(await April.name(), 'WETHUSDC 01-April-2030 200Put USDC Collateral')
-      assert.equal(await April.symbol(), 'oWETHUSDCUSDC-01APR30-200P')
+      assert.equal(await April.symbol(), 'oWETHUSDC/USDC-01APR30-200P')
 
       const May = await Otoken.new()
       await May.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1903824000, isPut, {
         from: deployer,
       })
       assert.equal(await May.name(), 'WETHUSDC 01-May-2030 200Put USDC Collateral')
-      assert.equal(await May.symbol(), 'oWETHUSDCUSDC-01MAY30-200P')
+      assert.equal(await May.symbol(), 'oWETHUSDC/USDC-01MAY30-200P')
 
       const June = await Otoken.new()
       await June.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1906502400, isPut, {
         from: deployer,
       })
       assert.equal(await June.name(), 'WETHUSDC 01-June-2030 200Put USDC Collateral')
-      assert.equal(await June.symbol(), 'oWETHUSDCUSDC-01JUN30-200P')
+      assert.equal(await June.symbol(), 'oWETHUSDC/USDC-01JUN30-200P')
 
       const July = await Otoken.new()
       await July.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1909094400, isPut, {
         from: deployer,
       })
       assert.equal(await July.name(), 'WETHUSDC 01-July-2030 200Put USDC Collateral')
-      assert.equal(await July.symbol(), 'oWETHUSDCUSDC-01JUL30-200P')
+      assert.equal(await July.symbol(), 'oWETHUSDC/USDC-01JUL30-200P')
 
       const August = await Otoken.new()
       await August.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1911772800, isPut, {
         from: deployer,
       })
       assert.equal(await August.name(), 'WETHUSDC 01-August-2030 200Put USDC Collateral')
-      assert.equal(await August.symbol(), 'oWETHUSDCUSDC-01AUG30-200P')
+      assert.equal(await August.symbol(), 'oWETHUSDC/USDC-01AUG30-200P')
 
       const September = await Otoken.new()
       await September.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1914451200, isPut, {
         from: deployer,
       })
       assert.equal(await September.name(), 'WETHUSDC 01-September-2030 200Put USDC Collateral')
-      assert.equal(await September.symbol(), 'oWETHUSDCUSDC-01SEP30-200P')
+      assert.equal(await September.symbol(), 'oWETHUSDC/USDC-01SEP30-200P')
 
       const October = await Otoken.new()
       await October.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1917043200, isPut, {
         from: deployer,
       })
       assert.equal(await October.name(), 'WETHUSDC 01-October-2030 200Put USDC Collateral')
-      assert.equal(await October.symbol(), 'oWETHUSDCUSDC-01OCT30-200P')
+      assert.equal(await October.symbol(), 'oWETHUSDC/USDC-01OCT30-200P')
 
       const November = await Otoken.new()
       await November.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1919721600, isPut, {
         from: deployer,
       })
       assert.equal(await November.name(), 'WETHUSDC 01-November-2030 200Put USDC Collateral')
-      assert.equal(await November.symbol(), 'oWETHUSDCUSDC-01NOV30-200P')
+      assert.equal(await November.symbol(), 'oWETHUSDC/USDC-01NOV30-200P')
 
       const December = await Otoken.new()
       await December.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1922313600, isPut, {
         from: deployer,
       })
       assert.equal(await December.name(), 'WETHUSDC 01-December-2030 200Put USDC Collateral')
-      assert.equal(await December.symbol(), 'oWETHUSDCUSDC-01DEC30-200P')
+      assert.equal(await December.symbol(), 'oWETHUSDC/USDC-01DEC30-200P')
     })
 
     it('should display strikePrice as $0 in name and symbol when strikePrice < 10^18', async () => {
@@ -258,7 +258,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await testOtoken.name(), `WETHUSDC 25-September-2020 0Put USDC Collateral`)
-      assert.equal(await testOtoken.symbol(), `oWETHUSDCUSDC-25SEP20-0P`)
+      assert.equal(await testOtoken.symbol(), `oWETHUSDC/USDC-25SEP20-0P`)
     })
   })
 

--- a/test/unit-tests/Otoken.test.ts
+++ b/test/unit-tests/Otoken.test.ts
@@ -70,7 +70,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await callOption.name(), `WETHUSDC 25-September-2020 200Call WETH Collateral`)
-      assert.equal(await callOption.symbol(), `oWETHUSDCUSDC-25SEP20-200C`)
+      assert.equal(await callOption.symbol(), `oWETHUSDCWETH-25SEP20-200C`)
     })
 
     it('should set the right name and symbol for option with strikePrice < 1', async () => {
@@ -179,77 +179,77 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await February.name(), 'WETHUSDC 01-February-2030 200Put USDC Collateral')
-      assert.equal(await February.symbol(), 'oWETHUSDC-01FEB30-200P')
+      assert.equal(await February.symbol(), 'oWETHUSDCUSDC-01FEB30-200P')
 
       const March = await Otoken.new()
       await March.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1898553600, isPut, {
         from: deployer,
       })
       assert.equal(await March.name(), 'WETHUSDC 01-March-2030 200Put USDC Collateral')
-      assert.equal(await March.symbol(), 'oWETHUSDC-01MAR30-200P')
+      assert.equal(await March.symbol(), 'oWETHUSDCUSDC-01MAR30-200P')
 
       const April = await Otoken.new()
       await April.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1901232000, isPut, {
         from: deployer,
       })
       assert.equal(await April.name(), 'WETHUSDC 01-April-2030 200Put USDC Collateral')
-      assert.equal(await April.symbol(), 'oWETHUSDC-01APR30-200P')
+      assert.equal(await April.symbol(), 'oWETHUSDCUSDC-01APR30-200P')
 
       const May = await Otoken.new()
       await May.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1903824000, isPut, {
         from: deployer,
       })
       assert.equal(await May.name(), 'WETHUSDC 01-May-2030 200Put USDC Collateral')
-      assert.equal(await May.symbol(), 'oWETHUSDC-01MAY30-200P')
+      assert.equal(await May.symbol(), 'oWETHUSDCUSDC-01MAY30-200P')
 
       const June = await Otoken.new()
       await June.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1906502400, isPut, {
         from: deployer,
       })
       assert.equal(await June.name(), 'WETHUSDC 01-June-2030 200Put USDC Collateral')
-      assert.equal(await June.symbol(), 'oWETHUSDC-01JUN30-200P')
+      assert.equal(await June.symbol(), 'oWETHUSDCUSDC-01JUN30-200P')
 
       const July = await Otoken.new()
       await July.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1909094400, isPut, {
         from: deployer,
       })
       assert.equal(await July.name(), 'WETHUSDC 01-July-2030 200Put USDC Collateral')
-      assert.equal(await July.symbol(), 'oWETHUSDC-01JUL30-200P')
+      assert.equal(await July.symbol(), 'oWETHUSDCUSDC-01JUL30-200P')
 
       const August = await Otoken.new()
       await August.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1911772800, isPut, {
         from: deployer,
       })
       assert.equal(await August.name(), 'WETHUSDC 01-August-2030 200Put USDC Collateral')
-      assert.equal(await August.symbol(), 'oWETHUSDC-01AUG30-200P')
+      assert.equal(await August.symbol(), 'oWETHUSDCUSDC-01AUG30-200P')
 
       const September = await Otoken.new()
       await September.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1914451200, isPut, {
         from: deployer,
       })
       assert.equal(await September.name(), 'WETHUSDC 01-September-2030 200Put USDC Collateral')
-      assert.equal(await September.symbol(), 'oWETHUSDC-01SEP30-200P')
+      assert.equal(await September.symbol(), 'oWETHUSDCUSDC-01SEP30-200P')
 
       const October = await Otoken.new()
       await October.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1917043200, isPut, {
         from: deployer,
       })
       assert.equal(await October.name(), 'WETHUSDC 01-October-2030 200Put USDC Collateral')
-      assert.equal(await October.symbol(), 'oWETHUSDC-01OCT30-200P')
+      assert.equal(await October.symbol(), 'oWETHUSDCUSDC-01OCT30-200P')
 
       const November = await Otoken.new()
       await November.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1919721600, isPut, {
         from: deployer,
       })
       assert.equal(await November.name(), 'WETHUSDC 01-November-2030 200Put USDC Collateral')
-      assert.equal(await November.symbol(), 'oWETHUSDC-01NOV30-200P')
+      assert.equal(await November.symbol(), 'oWETHUSDCUSDC-01NOV30-200P')
 
       const December = await Otoken.new()
       await December.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1922313600, isPut, {
         from: deployer,
       })
       assert.equal(await December.name(), 'WETHUSDC 01-December-2030 200Put USDC Collateral')
-      assert.equal(await December.symbol(), 'oWETHUSDC-01DEC30-200P')
+      assert.equal(await December.symbol(), 'oWETHUSDCUSDC-01DEC30-200P')
     })
 
     it('should display strikePrice as $0 in name and symbol when strikePrice < 10^18', async () => {

--- a/test/unit-tests/Otoken.test.ts
+++ b/test/unit-tests/Otoken.test.ts
@@ -46,7 +46,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
 
     it('should initilized the put option with valid name / symbol', async () => {
       assert.equal(await otoken.name(), `WETHUSDC 25-September-2020 200Put USDC Collateral`)
-      assert.equal(await otoken.symbol(), `oWETHUSDC-25SEP20-200P`)
+      assert.equal(await otoken.symbol(), `oWETHUSDCUSDC-25SEP20-200P`)
       assert.equal((await otoken.decimals()).toNumber(), 8)
     })
 
@@ -70,7 +70,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await callOption.name(), `WETHUSDC 25-September-2020 200Call WETH Collateral`)
-      assert.equal(await callOption.symbol(), `oWETHUSDC-25SEP20-200C`)
+      assert.equal(await callOption.symbol(), `oWETHUSDCUSDC-25SEP20-200C`)
     })
 
     it('should set the right name and symbol for option with strikePrice < 1', async () => {
@@ -81,7 +81,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await o1.name(), `WETHUSDC 25-September-2020 0.5Put USDC Collateral`)
-      assert.equal(await o1.symbol(), `oWETHUSDC-25SEP20-0.5P`)
+      assert.equal(await o1.symbol(), `oWETHUSDCUSDC-25SEP20-0.5P`)
     })
 
     it('should set the right name and symbol for option with strikePrice < 1, with 8 decimals', async () => {
@@ -92,7 +92,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await o2.name(), `WETHUSDC 25-September-2020 0.00010052Put USDC Collateral`)
-      assert.equal(await o2.symbol(), `oWETHUSDC-25SEP20-0.00010052P`)
+      assert.equal(await o2.symbol(), `oWETHUSDCUSDC-25SEP20-0.00010052P`)
     })
 
     it('should set the right name and symbol for option with strikePrice < 1, with starting and trailing zeroes.', async () => {
@@ -102,7 +102,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await o3.name(), `WETHUSDC 25-September-2020 0.0729Put USDC Collateral`)
-      assert.equal(await o3.symbol(), `oWETHUSDC-25SEP20-0.0729P`)
+      assert.equal(await o3.symbol(), `oWETHUSDCUSDC-25SEP20-0.0729P`)
     })
 
     it('should set the right name for option with strikePrice 0', async () => {
@@ -112,7 +112,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await oToken.name(), `WETHUSDC 25-September-2020 0Put USDC Collateral`)
-      assert.equal(await oToken.symbol(), `oWETHUSDC-25SEP20-0P`)
+      assert.equal(await oToken.symbol(), `oWETHUSDCUSDC-25SEP20-0P`)
     })
 
     it('should set the right name for non-eth options', async () => {
@@ -122,7 +122,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await putOption.name(), `WETHUSDC 25-September-2020 200Put USDC Collateral`)
-      assert.equal(await putOption.symbol(), `oWETHUSDC-25SEP20-200P`)
+      assert.equal(await putOption.symbol(), `oWETHUSDCUSDC-25SEP20-200P`)
     })
 
     it('should revert when init asset with non-erc20 address', async () => {
@@ -141,7 +141,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await otoken.name(), `WETHUSDC 01-January-1970 200Put USDC Collateral`)
-      assert.equal(await otoken.symbol(), `oWETHUSDC-01JAN70-200P`)
+      assert.equal(await otoken.symbol(), `oWETHUSDCUSDC-01JAN70-200P`)
     })
 
     it('should set the right name for options expiry on 2345/12/31', async () => {
@@ -152,7 +152,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await otoken.name(), `WETHUSDC 31-December-2345 200Put USDC Collateral`)
-      assert.equal(await otoken.symbol(), `oWETHUSDC-31DEC45-200P`)
+      assert.equal(await otoken.symbol(), `oWETHUSDCUSDC-31DEC45-200P`)
     })
 
     it('should set the right symbol for year 220x ', async () => {
@@ -161,7 +161,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
       await otoken.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, expiry, true, {
         from: deployer,
       })
-      assert.equal(await otoken.symbol(), 'oWETHUSDC-29JUL09-200P')
+      assert.equal(await otoken.symbol(), 'oWETHUSDCUSDC-29JUL09-200P')
       assert.equal(await otoken.name(), 'WETHUSDC 29-July-2209 200Put USDC Collateral')
     })
 
@@ -172,7 +172,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await January.name(), 'WETHUSDC 01-January-2030 200Put USDC Collateral')
-      assert.equal(await January.symbol(), 'oWETHUSDC-01JAN30-200P')
+      assert.equal(await January.symbol(), 'oWETHUSDCUSDC-01JAN30-200P')
 
       const February = await Otoken.new()
       await February.init(addressBookAddr, weth.address, usdc.address, usdc.address, strikePrice, 1896134400, isPut, {
@@ -258,7 +258,7 @@ contract('Otoken', ([deployer, controller, user1, user2, random]) => {
         from: deployer,
       })
       assert.equal(await testOtoken.name(), `WETHUSDC 25-September-2020 0Put USDC Collateral`)
-      assert.equal(await testOtoken.symbol(), `oWETHUSDC-25SEP20-0P`)
+      assert.equal(await testOtoken.symbol(), `oWETHUSDCUSDC-25SEP20-0P`)
     })
   })
 

--- a/test/unit-tests/oracle.test.ts
+++ b/test/unit-tests/oracle.test.ts
@@ -21,7 +21,7 @@ const Oracle = artifacts.require('Oracle.sol')
 const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
 
 contract('Oracle', ([owner, disputer, random, collateral, strike]) => {
-  // const batch = web3.utils.asciiToHex('ETHUSDCUSDC1596218762')
+  // const batch = web3.utils.asciiToHex('ETHUSDC/USDC1596218762')
   // mock a pricer
   let wethPricer: MockPricerInstance
   // AddressBook module


### PR DESCRIPTION
# [L09] oToken symbols might not be unique

## High Level Description

This PR add the collateral asset in the Otoken symbol.

e.g:
before: oETHUSDC-05SEP20-200P
now: oETHUSDC/USDC-05SEP20-200P

### Code

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?

### Documentation

- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
