### PR TITLE
[N06] Typographical errors and misleading comments

### DIFF
--- a/contracts/AddressBook.sol
+++ b/contracts/AddressBook.sol
@@ -194,7 +194,7 @@ contract AddressBook is Ownable {
     }
 
     /**
-     * @dev internal function to update the implementation of a specific component of the protocol
+     * @dev function to update the implementation of a specific component of the protocol
      * @param _id id of the contract to be updated
      * @param _newAddress address of the new implementation
      **/

--- a/contracts/MarginCalculator.sol
+++ b/contracts/MarginCalculator.sol
@@ -87,8 +87,8 @@ contract MarginCalculator {
 
         FPI.FixedPointInt memory collateralAmount = ZERO;
         if (hasCollateral) {
-            uint256 colllateralDecimals = ERC20Interface(_vault.collateralAssets[0]).decimals();
-            collateralAmount = FPI.fromScaledUint(_vault.collateralAmounts[0], colllateralDecimals);
+            uint256 collateralDecimals = ERC20Interface(_vault.collateralAssets[0]).decimals();
+            collateralAmount = FPI.fromScaledUint(_vault.collateralAmounts[0], collateralDecimals);
         }
 
         // get required margin, denominated in collateral

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -63,7 +63,7 @@ contract Oracle is Ownable {
      * @notice get a live asset price from the asset's pricer contract
      * @param _asset asset address
      * @return price scaled by 1e8, denominated in USD
-     * e.g. 17368900000 => 175.689 USD
+     * e.g. 17568900000 => 175.689 USD
      */
     function getPrice(address _asset) external view returns (uint256) {
         require(assetPricer[_asset] != address(0), "Oracle: Pricer for this asset not set");
@@ -207,7 +207,7 @@ contract Oracle is Ownable {
 
     /**
      * @notice dispute an asset price during the dispute period
-     * @dev only the owner can dispute a price during the dispute period, by setting a new one
+     * @dev only the disputer can dispute a price during the dispute period, by setting a new one
      * @param _asset asset address
      * @param _expiryTimestamp expiry timestamp
      * @param _price the correct price
@@ -239,10 +239,7 @@ contract Oracle is Ownable {
         uint256 _expiryTimestamp,
         uint256 _price
     ) external {
-        require(
-            (msg.sender == assetPricer[_asset]) || (msg.sender == disputer),
-            "Oracle: caller is not authorized to set expiry price"
-        );
+        require(msg.sender == assetPricer[_asset], "Oracle: caller is not authorized to set expiry price");
         require(isLockingPeriodOver(_asset, _expiryTimestamp), "Oracle: locking period is not over yet");
         require(storedPrice[_asset][_expiryTimestamp].timestamp == 0, "Oracle: dispute period started");
 

--- a/contracts/Whitelist.sol
+++ b/contracts/Whitelist.sol
@@ -214,7 +214,7 @@ contract Whitelist is Ownable {
      * @dev can only be called from the owner address
      * @param _callee callee address
      */
-    function whitelisteCallee(address _callee) external onlyOwner {
+    function whitelistCallee(address _callee) external onlyOwner {
         whitelistedCallee[_callee] = true;
 
         emit CalleeWhitelisted(_callee);

--- a/contracts/libs/MarginVault.sol
+++ b/contracts/libs/MarginVault.sol
@@ -79,10 +79,8 @@ library MarginVault {
         uint256 _index
     ) external {
         // check that the removed short oToken exists in the vault at the specified index
-        require(
-            (_index < _vault.shortOtokens.length) && (_vault.shortOtokens[_index] == _shortOtoken),
-            "MarginVault: short otoken address mismatch"
-        );
+        require(_index < _vault.shortOtokens.length, "MarginVault: invalid short otoken index");
+        require(_vault.shortOtokens[_index] == _shortOtoken, "MarginVault: short otoken address mismatch");
 
         _vault.shortAmounts[_index] = _vault.shortAmounts[_index].sub(_amount);
 
@@ -136,10 +134,8 @@ library MarginVault {
         uint256 _index
     ) external {
         // check that the removed long oToken exists in the vault at the specified index
-        require(
-            (_index < _vault.longOtokens.length) && (_vault.longOtokens[_index] == _longOtoken),
-            "MarginVault: long otoken address mismatch"
-        );
+        require(_index < _vault.longOtokens.length, "MarginVault: invalid long otoken index");
+        require(_vault.longOtokens[_index] == _longOtoken, "MarginVault: long otoken address mismatch");
 
         _vault.longAmounts[_index] = _vault.longAmounts[_index].sub(_amount);
 
@@ -194,10 +190,8 @@ library MarginVault {
         uint256 _index
     ) external {
         // check that the removed collateral exists in the vault at the specified index
-        require(
-            (_index < _vault.collateralAssets.length) && (_vault.collateralAssets[_index] == _collateralAsset),
-            "MarginVault: collateral token address mismatch"
-        );
+        require(_index < _vault.collateralAssets.length, "MarginVault: invalid collateral asset index");
+        require(_vault.collateralAssets[_index] == _collateralAsset, "MarginVault: collateral token address mismatch");
 
         _vault.collateralAmounts[_index] = _vault.collateralAmounts[_index].sub(_amount);
 

--- a/contracts/mocks/MockWhitelistModule.sol
+++ b/contracts/mocks/MockWhitelistModule.sol
@@ -50,7 +50,7 @@ contract MockWhitelistModule {
         return whitelistedCallee[_callee];
     }
 
-    function whitelisteCallee(address _callee) external {
+    function whitelistCallee(address _callee) external {
         whitelistedCallee[_callee] = true;
     }
 

--- a/docs/contracts-documentation/Whitelist.md
+++ b/docs/contracts-documentation/Whitelist.md
@@ -30,7 +30,7 @@ The whitelist module keeps track of all valid oToken addresses, product hashes, 
 
 - `blacklistOtoken(address _otokenAddress) (external)`
 
-- `whitelisteCallee(address _callee) (external)`
+- `whitelistCallee(address _callee) (external)`
 
 - `blacklistCallee(address _callee) (external)`
 
@@ -196,7 +196,7 @@ can only be called from the owner address
 
 - `_otokenAddress`: oToken
 
-### Function `whitelisteCallee(address _callee) external`
+### Function `whitelistCallee(address _callee) external`
 
 allows the owner to whitelist a destination address for the call action
 

--- a/docs/contracts-documentation/mocks/MockWhitelistModule.md
+++ b/docs/contracts-documentation/mocks/MockWhitelistModule.md
@@ -16,7 +16,7 @@
 
 - `isWhitelistedCallee(address _callee) (external)`
 
-- `whitelisteCallee(address _callee) (external)`
+- `whitelistCallee(address _callee) (external)`
 
 - `blacklistCallee(address _callee) (external)`
 
@@ -34,6 +34,6 @@
 
 ### Function `isWhitelistedCallee(address _callee) → bool external`
 
-### Function `whitelisteCallee(address _callee) external`
+### Function `whitelistCallee(address _callee) external`
 
 ### Function `blacklistCallee(address _callee) external`

--- a/docs/uml/GammaUML.svg
+++ b/docs/uml/GammaUML.svg
@@ -629,7 +629,7 @@
 <text text-anchor="start" x="3504.9053" y="-1632.1" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;blacklistCollateral(_collateral: address)</text>
 <text text-anchor="start" x="3504.9053" y="-1615.3" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;whitelistOtoken(_otokenAddress: address)</text>
 <text text-anchor="start" x="3504.9053" y="-1598.5" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;blacklistOtoken(_otokenAddress: address)</text>
-<text text-anchor="start" x="3504.9053" y="-1581.7" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;whitelisteCallee(_callee: address)</text>
+<text text-anchor="start" x="3504.9053" y="-1581.7" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;whitelistCallee(_callee: address)</text>
 <text text-anchor="start" x="3504.9053" y="-1564.9" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;blacklistCallee(_callee: address)</text>
 <text text-anchor="start" x="3504.9053" y="-1548.1" font-family="Times,serif" font-size="14.00" fill="#000000">Public:</text>
 <text text-anchor="start" x="3504.9053" y="-1531.3" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;&lt;&lt;event&gt;&gt; ProductWhitelisted(productHash: bytes32, underlying: address, strike: address, collateral: address, isPut: bool)</text>
@@ -1739,7 +1739,7 @@
 <text text-anchor="start" x="16803.9575" y="-579.9" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;isWhitelistedCollateral(_collateral: address): bool</text>
 <text text-anchor="start" x="16803.9575" y="-563.1" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;whitelistCollateral(_collateral: address)</text>
 <text text-anchor="start" x="16803.9575" y="-546.3" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;isWhitelistedCallee(_callee: address): bool</text>
-<text text-anchor="start" x="16803.9575" y="-529.5" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;whitelisteCallee(_callee: address)</text>
+<text text-anchor="start" x="16803.9575" y="-529.5" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;whitelistCallee(_callee: address)</text>
 <text text-anchor="start" x="16803.9575" y="-512.7" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;blacklistCallee(_callee: address)</text>
 </g>
 <!-- 25 -->

--- a/docs/uml/GammaWhitelist.svg
+++ b/docs/uml/GammaWhitelist.svg
@@ -34,7 +34,7 @@
 <text text-anchor="start" x="8" y="-260.7" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;blacklistCollateral(_collateral: address)</text>
 <text text-anchor="start" x="8" y="-243.9" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;whitelistOtoken(_otokenAddress: address)</text>
 <text text-anchor="start" x="8" y="-227.1" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;blacklistOtoken(_otokenAddress: address)</text>
-<text text-anchor="start" x="8" y="-210.3" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;whitelisteCallee(_callee: address)</text>
+<text text-anchor="start" x="8" y="-210.3" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;whitelistCallee(_callee: address)</text>
 <text text-anchor="start" x="8" y="-193.5" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;blacklistCallee(_callee: address)</text>
 <text text-anchor="start" x="8" y="-176.7" font-family="Times,serif" font-size="14.00" fill="#000000">Public:</text>
 <text text-anchor="start" x="8" y="-159.9" font-family="Times,serif" font-size="14.00" fill="#000000"> &#160;&#160;&#160;&lt;&lt;event&gt;&gt; ProductWhitelisted(productHash: bytes32, underlying: address, strike: address, collateral: address, isPut: bool)</text>

--- a/test/unit-tests/Whitelist.test.ts
+++ b/test/unit-tests/Whitelist.test.ts
@@ -191,11 +191,11 @@ contract('Whitelist', ([owner, otokenFactoryAddress, random, newOwner, callee]) 
 
   describe('Whitelist callee', () => {
     it('should revert whitelisting callee from non-owner address', async () => {
-      await expectRevert(whitelist.whitelisteCallee(callee, {from: random}), 'Ownable: caller is not the owner')
+      await expectRevert(whitelist.whitelistCallee(callee, {from: random}), 'Ownable: caller is not the owner')
     })
 
     it('should whitelist callee from owner address', async () => {
-      const whitelistTx = await whitelist.whitelisteCallee(callee, {from: owner})
+      const whitelistTx = await whitelist.whitelistCallee(callee, {from: owner})
 
       expectEvent(whitelistTx, 'CalleeWhitelisted')
 

--- a/test/unit-tests/controller.test.ts
+++ b/test/unit-tests/controller.test.ts
@@ -747,7 +747,7 @@ contract(
 
           await expectRevert(
             controllerProxy.operate(actionArgs, {from: accountOwner1}),
-            'MarginVault: long otoken address mismatch',
+            'MarginVault: invalid long otoken index',
           )
         })
 
@@ -1425,7 +1425,7 @@ contract(
 
           await expectRevert(
             controllerProxy.operate(actionArgs, {from: accountOwner1}),
-            'MarginVault: collateral token address mismatch',
+            'MarginVault: invalid collateral asset index',
           )
         })
 
@@ -2280,7 +2280,7 @@ contract(
 
           await expectRevert(
             controllerProxy.operate(actionArgs, {from: accountOwner1}),
-            'MarginVault: short otoken address mismatch',
+            'MarginVault: invalid short otoken index',
           )
         })
 
@@ -2301,14 +2301,14 @@ contract(
               asset: shortOtoken.address,
               vaultId: vaultCounter.toNumber(),
               amount: shortOtokenToBurn.toString(),
-              index: '1',
+              index: '0',
               data: ZERO_ADDR,
             },
           ]
 
           await expectRevert(
             controllerProxy.operate(actionArgs, {from: accountOperator1}),
-            'MarginVault: short otoken address mismatch',
+            'ERC20: burn amount exceeds balance',
           )
 
           // transfer back
@@ -3920,7 +3920,7 @@ contract(
 
       it('should call whitelisted callee address when restriction is activated', async () => {
         // whitelist callee
-        await whitelist.whitelisteCallee(callTester.address, {from: owner})
+        await whitelist.whitelistCallee(callTester.address, {from: owner})
 
         const actionArgs = [
           {

--- a/test/unit-tests/oracle.test.ts
+++ b/test/unit-tests/oracle.test.ts
@@ -263,13 +263,11 @@ contract('Oracle', ([owner, disputer, random, collateral, strike]) => {
       await oracle.setDisputer(disputer, {from: owner})
     })
 
-    it('should set price correctly from disputer', async () => {
-      // setExpiryPrice is called from disputer
-      await oracle.setExpiryPrice(weth.address, otokenExpiry, assetPrice, {from: disputer})
-
-      const [price, isFinalized] = await oracle.getExpiryPrice(weth.address, otokenExpiry)
-      assert.equal(price.toString(), assetPrice.toString())
-      assert.equal(isFinalized, false)
+    it('should revert setting price from disputer address', async () => {
+      await expectRevert(
+        oracle.setExpiryPrice(weth.address, otokenExpiry, assetPrice, {from: disputer}),
+        'Oracle: caller is not authorized to set expiry price',
+      )
     })
   })
 })


### PR DESCRIPTION
# [N06] Typographical errors and misleading comments

## High Level Description

- Fix some typo errors
- Allow only pricer to push price at expiry
- Add another require statement in the remove functions in `MarginVault` to distinguish between invalid index error and asset address mismatch error.

### Code

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?

### Documentation

- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
