### PR TITLE
[M02] - ERC20 compliant assets may not be used

### DIFF
--- a/contracts/interfaces/ERC20Interface.sol
+++ b/contracts/interfaces/ERC20Interface.sol
@@ -81,4 +81,10 @@ interface ERC20Interface {
      * a call to {approve}. `value` is the new allowance.
      */
     event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() external view returns (string memory);
 }

--- a/contracts/mocks/MockNoDecimalERC20.sol
+++ b/contracts/mocks/MockNoDecimalERC20.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+/* solhint-disable */
+pragma solidity ^0.6.0;
+
+import {SafeMath} from "../packages/oz/SafeMath.sol";
+
+/**
+ * ERC20 Token that return false when operation failed
+ */
+contract MockNoDecimalERC20 {
+    using SafeMath for uint256;
+
+    mapping(address => uint256) private _balances;
+
+    mapping(address => mapping(address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    string private _symbol;
+
+    /**
+     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
+     * a default value of 18.
+     *
+     * To select a different value for {decimals}, use {_setupDecimals}.
+     *
+     * All three of these values are immutable: they can only be set once during
+     * construction.
+     */
+    constructor(string memory name_, string memory symbol_) public {
+        _name = name_;
+        _symbol = symbol_;
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view returns (uint256) {
+        return _totalSupply;
+    }
+}

--- a/contracts/mocks/MockNoSymbolERC20.sol
+++ b/contracts/mocks/MockNoSymbolERC20.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+/* solhint-disable */
+pragma solidity ^0.6.0;
+
+import {SafeMath} from "../packages/oz/SafeMath.sol";
+
+/**
+ * ERC20 Token that return false when operation failed
+ */
+contract MockNoSymbolERC20 {
+    using SafeMath for uint256;
+
+    mapping(address => uint256) private _balances;
+
+    mapping(address => mapping(address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    uint8 private _decimals;
+
+    /**
+     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
+     * a default value of 18.
+     *
+     * To select a different value for {decimals}, use {_setupDecimals}.
+     *
+     * All three of these values are immutable: they can only be set once during
+     * construction.
+     */
+    constructor(string memory name_) public {
+        _name = name_;
+        _decimals = 18;
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public view returns (uint8) {
+        return _decimals;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view returns (uint256) {
+        return _totalSupply;
+    }
+}


### PR DESCRIPTION
# Task: Feature Name: [M02] - ERC20 compliant assets may not be used

## High Level Description
require statement to ensure that decimals are within range
require statement to ensure that symbol is not ""
these require statements cause a non-elegant revert if symbols/decimals are not defined which prevents whitelisting of not acceptable erc-20s

unit tests updated to handle branches of symbol/decimal logic

Few ways to handle fetching the symbol/decimal, welcome suggestions if I can improve the implementation.

Initial implementation was calling ERC20Interface(_asset).decimals in the require statement, but switched to declaring variables for decimals and symbol.

I'd think I can also define the asset and call asset.decimals() and asset.symbol() in the require.

### Code

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?

### Documentation

- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
