### PR TITLE
Checks when adding pricer or stable price

### DIFF
--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -178,7 +178,7 @@ contract Oracle is Ownable {
      */
     function setAssetPricer(address _asset, address _pricer) external onlyOwner {
         require(_pricer != address(0), "Oracle: cannot set pricer to address(0)");
-        require(stablePrice[_asset] == 0, "Oracle: could not set a price for stable asset");
+        require(stablePrice[_asset] == 0, "Oracle: could not set a pricer for stable asset");
 
         assetPricer[_asset] = _pricer;
 

--- a/contracts/Oracle.sol
+++ b/contracts/Oracle.sol
@@ -178,6 +178,8 @@ contract Oracle is Ownable {
      */
     function setAssetPricer(address _asset, address _pricer) external onlyOwner {
         require(_pricer != address(0), "Oracle: cannot set pricer to address(0)");
+        require(stablePrice[_asset] == 0, "Oracle: could not set a price for stable asset");
+
         assetPricer[_asset] = _pricer;
 
         emit PricerUpdated(_asset, _pricer);
@@ -229,6 +231,8 @@ contract Oracle is Ownable {
      * @param _price price
      */
     function setStablePrice(address _asset, uint256 _price) external onlyOwner {
+        require(assetPricer[_asset] == address(0), "Oracle: could not set stable price for an asset with pricer");
+
         stablePrice[_asset] = _price;
 
         emit StablePriceUpdated(_asset, _price);

--- a/test/unit-tests/oracle.test.ts
+++ b/test/unit-tests/oracle.test.ts
@@ -71,6 +71,15 @@ contract('Oracle', ([owner, disputer, random, collateral, strike]) => {
 
       assert.equal(await oracle.getPricer(weth.address), wethPricer.address, 'batch oracle address mismatch')
     })
+
+    it('should revert setting a stable price for an asset that have a pricer', async () => {
+      const stablePrice = createTokenAmount(1000, 8)
+
+      await expectRevert(
+        oracle.setStablePrice(weth.address, stablePrice, {from: owner}),
+        'Oracle: could not set stable price for an asset with pricer',
+      )
+    })
   })
 
   describe('Get live price.', () => {
@@ -296,6 +305,15 @@ contract('Oracle', ([owner, disputer, random, collateral, strike]) => {
         (await oracle.getExpiryPrice(usdc.address, otokenExpiry))[0].toString(),
         stablePrice,
         'Stable price mismatch',
+      )
+    })
+
+    it('should revert setting a pricer for an asset that have a stable price', async () => {
+      const usdcPricer = await MockPricer.new(usdc.address, oracle.address)
+
+      await expectRevert(
+        oracle.setAssetPricer(usdc.address, usdcPricer.address, {from: owner}),
+        'Oracle: could not set a pricer for stable asset',
       )
     })
   })


### PR DESCRIPTION
# Checks when adding pricer or stable price

## High Level Description

This PR add a check statements when adding a pricer or stable price for a certain assert:
- when set a pricer, check that the asset have no stable price
- when set s stable price, check that the asset have no pricer.

### Code

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?

### Documentation

- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
