### PR TITLE
Refactor marginVault to reduce # of SLOAD

### DIFF
--- a/contracts/libs/MarginVault.sol
+++ b/contracts/libs/MarginVault.sol
@@ -89,12 +89,8 @@ library MarginVault {
 
         uint256 newShortAmount = _vault.shortAmounts[_index].sub(_amount);
 
-        if (newShortAmount == 0) {
-            delete _vault.shortOtokens[_index];
-            delete _vault.shortAmounts[_index];
-        } else {
-            _vault.shortAmounts[_index] = newShortAmount;
-        }
+        if (newShortAmount == 0) delete _vault.shortOtokens[_index];
+        _vault.shortAmounts[_index] = newShortAmount;
     }
 
     /**
@@ -152,12 +148,8 @@ library MarginVault {
 
         uint256 newLongAmount = _vault.longAmounts[_index].sub(_amount);
 
-        if (newLongAmount == 0) {
-            delete _vault.longOtokens[_index];
-            delete _vault.longAmounts[_index];
-        } else {
-            _vault.longAmounts[_index] = newLongAmount;
-        }
+        if (newLongAmount == 0) delete _vault.longOtokens[_index];
+        _vault.longAmounts[_index] = newLongAmount;
     }
 
     /**
@@ -215,11 +207,7 @@ library MarginVault {
 
         uint256 newCollateralAmount = _vault.collateralAmounts[_index].sub(_amount);
 
-        if (newCollateralAmount == 0) {
-            delete _vault.collateralAssets[_index];
-            delete _vault.collateralAmounts[_index];
-        } else {
-            _vault.collateralAmounts[_index] = newCollateralAmount;
-        }
+        if (newCollateralAmount == 0) delete _vault.collateralAssets[_index];
+        _vault.collateralAmounts[_index] = newCollateralAmount;
     }
 }

--- a/contracts/libs/MarginVault.sol
+++ b/contracts/libs/MarginVault.sol
@@ -59,8 +59,9 @@ library MarginVault {
                 (_index < _vault.shortOtokens.length) && (_index < _vault.shortAmounts.length),
                 "MarginVault: invalid short otoken index"
             );
+            address existingShort = _vault.shortOtokens[_index];
             require(
-                (_vault.shortOtokens[_index] == _shortOtoken) || (_vault.shortOtokens[_index] == address(0)),
+                (existingShort == _shortOtoken) || (existingShort == address(0)),
                 "MarginVault: short otoken address mismatch"
             );
 
@@ -86,10 +87,14 @@ library MarginVault {
         require(_index < _vault.shortOtokens.length, "MarginVault: invalid short otoken index");
         require(_vault.shortOtokens[_index] == _shortOtoken, "MarginVault: short otoken address mismatch");
 
-        _vault.shortAmounts[_index] = _vault.shortAmounts[_index].sub(_amount);
+        uint256 newShortAmount = _vault.shortAmounts[_index].sub(_amount);
+        // _vault.shortAmounts[_index] = _vault.shortAmounts[_index].sub(_amount);
 
-        if (_vault.shortAmounts[_index] == 0) {
+        if (newShortAmount == 0) {
             delete _vault.shortOtokens[_index];
+            delete _vault.shortAmounts[_index];
+        } else {
+            _vault.shortAmounts[_index] = newShortAmount;
         }
     }
 
@@ -118,8 +123,9 @@ library MarginVault {
                 (_index < _vault.longOtokens.length) && (_index < _vault.longAmounts.length),
                 "MarginVault: invalid long otoken index"
             );
+            address existingLong = _vault.longOtokens[_index];
             require(
-                (_vault.longOtokens[_index] == _longOtoken) || (_vault.longOtokens[_index] == address(0)),
+                (existingLong == _longOtoken) || (existingLong == address(0)),
                 "MarginVault: long otoken address mismatch"
             );
 
@@ -145,10 +151,13 @@ library MarginVault {
         require(_index < _vault.longOtokens.length, "MarginVault: invalid long otoken index");
         require(_vault.longOtokens[_index] == _longOtoken, "MarginVault: long otoken address mismatch");
 
-        _vault.longAmounts[_index] = _vault.longAmounts[_index].sub(_amount);
+        uint256 newLongAmount = _vault.longAmounts[_index].sub(_amount);
 
-        if (_vault.longAmounts[_index] == 0) {
+        if (newLongAmount == 0) {
             delete _vault.longOtokens[_index];
+            delete _vault.longAmounts[_index];
+        } else {
+            _vault.longAmounts[_index] = newLongAmount;
         }
     }
 

--- a/contracts/libs/MarginVault.sol
+++ b/contracts/libs/MarginVault.sol
@@ -89,7 +89,9 @@ library MarginVault {
 
         uint256 newShortAmount = _vault.shortAmounts[_index].sub(_amount);
 
-        if (newShortAmount == 0) delete _vault.shortOtokens[_index];
+        if (newShortAmount == 0) {
+            delete _vault.shortOtokens[_index];
+        }
         _vault.shortAmounts[_index] = newShortAmount;
     }
 
@@ -148,7 +150,9 @@ library MarginVault {
 
         uint256 newLongAmount = _vault.longAmounts[_index].sub(_amount);
 
-        if (newLongAmount == 0) delete _vault.longOtokens[_index];
+        if (newLongAmount == 0) {
+            delete _vault.longOtokens[_index];
+        }
         _vault.longAmounts[_index] = newLongAmount;
     }
 
@@ -207,7 +211,9 @@ library MarginVault {
 
         uint256 newCollateralAmount = _vault.collateralAmounts[_index].sub(_amount);
 
-        if (newCollateralAmount == 0) delete _vault.collateralAssets[_index];
+        if (newCollateralAmount == 0) {
+            delete _vault.collateralAssets[_index];
+        }
         _vault.collateralAmounts[_index] = newCollateralAmount;
     }
 }

--- a/contracts/libs/MarginVault.sol
+++ b/contracts/libs/MarginVault.sol
@@ -88,7 +88,6 @@ library MarginVault {
         require(_vault.shortOtokens[_index] == _shortOtoken, "MarginVault: short otoken address mismatch");
 
         uint256 newShortAmount = _vault.shortAmounts[_index].sub(_amount);
-        // _vault.shortAmounts[_index] = _vault.shortAmounts[_index].sub(_amount);
 
         if (newShortAmount == 0) {
             delete _vault.shortOtokens[_index];
@@ -186,9 +185,9 @@ library MarginVault {
                 (_index < _vault.collateralAssets.length) && (_index < _vault.collateralAmounts.length),
                 "MarginVault: invalid collateral token index"
             );
+            address existingCollateral = _vault.collateralAssets[_index];
             require(
-                (_vault.collateralAssets[_index] == _collateralAsset) ||
-                    (_vault.collateralAssets[_index] == address(0)),
+                (existingCollateral == _collateralAsset) || (existingCollateral == address(0)),
                 "MarginVault: collateral token address mismatch"
             );
 
@@ -214,10 +213,13 @@ library MarginVault {
         require(_index < _vault.collateralAssets.length, "MarginVault: invalid collateral asset index");
         require(_vault.collateralAssets[_index] == _collateralAsset, "MarginVault: collateral token address mismatch");
 
-        _vault.collateralAmounts[_index] = _vault.collateralAmounts[_index].sub(_amount);
+        uint256 newCollateralAmount = _vault.collateralAmounts[_index].sub(_amount);
 
-        if (_vault.collateralAmounts[_index] == 0) {
+        if (newCollateralAmount == 0) {
             delete _vault.collateralAssets[_index];
+            delete _vault.collateralAmounts[_index];
+        } else {
+            _vault.collateralAmounts[_index] = newCollateralAmount;
         }
     }
 }


### PR DESCRIPTION
# Task: Optimize SLOAD in `MarginVault.sol`

## High Level Description

1. small improvement (~1%) on `addLong`, `addShort` and `addCollateral` by caching `_vault.shortOtokens[_index]` instead of reading it twice.
2. bigger improvement (4~5%) on removeLong, removeShort and removeCollateral, by caching the new amount after deduction instead of reading it twice

### Gas cost before optimization
![image](https://user-images.githubusercontent.com/20136488/113514884-a37cb900-95a3-11eb-82f7-16d8deda3fce.png)


### After Optimization

![image](https://user-images.githubusercontent.com/20136488/113514998-5ea55200-95a4-11eb-925e-4f89c321fdb6.png)

### Todos

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?
