### PR TITLE
Chore: undo vault type changes in old integration tests

### DIFF
--- a/test/integration-tests/longCallSpreadExpireItm.test.ts
+++ b/test/integration-tests/longCallSpreadExpireItm.test.ts
@@ -70,8 +70,6 @@ contract('Long Call Spread Option expires Itm flow', ([accountOwner1, nakedBuyer
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -193,7 +191,7 @@ contract('Long Call Spread Option expires Itm flow', ([accountOwner1, nakedBuyer
             vaultId: vaultCounter2,
             amount: '0',
             index: '0',
-            data: openVaultBytes,
+            data: ZERO_ADDR,
           },
           {
             actionType: ActionType.MintShortOption,
@@ -231,7 +229,7 @@ contract('Long Call Spread Option expires Itm flow', ([accountOwner1, nakedBuyer
             vaultId: vaultCounter1,
             amount: '0',
             index: '0',
-            data: openVaultBytes,
+            data: ZERO_ADDR,
           },
           {
             actionType: ActionType.MintShortOption,

--- a/test/integration-tests/longCallSpreadExpireOtm.test.ts
+++ b/test/integration-tests/longCallSpreadExpireOtm.test.ts
@@ -70,8 +70,6 @@ contract('Long Call Spread Option expires Otm flow', ([accountOwner1, nakedBuyer
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -192,7 +190,7 @@ contract('Long Call Spread Option expires Otm flow', ([accountOwner1, nakedBuyer
             vaultId: vaultCounter2,
             amount: '0',
             index: '0',
-            data: openVaultBytes,
+            data: ZERO_ADDR,
           },
           {
             actionType: ActionType.MintShortOption,
@@ -230,7 +228,7 @@ contract('Long Call Spread Option expires Otm flow', ([accountOwner1, nakedBuyer
             vaultId: vaultCounter1,
             amount: '0',
             index: '0',
-            data: openVaultBytes,
+            data: ZERO_ADDR,
           },
           {
             actionType: ActionType.MintShortOption,

--- a/test/integration-tests/longCallSpreadPreExpiry.test.ts
+++ b/test/integration-tests/longCallSpreadPreExpiry.test.ts
@@ -70,8 +70,6 @@ contract('Long Call Spread Option closed before expiry flow', ([accountOwner1, n
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -190,7 +188,7 @@ contract('Long Call Spread Option closed before expiry flow', ([accountOwner1, n
           vaultId: vaultCounter2,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,
@@ -265,7 +263,7 @@ contract('Long Call Spread Option closed before expiry flow', ([accountOwner1, n
           vaultId: vaultCounter1,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,

--- a/test/integration-tests/longPutExpireItm.test.ts
+++ b/test/integration-tests/longPutExpireItm.test.ts
@@ -70,8 +70,6 @@ contract('Long Put Spread Option closed ITM flow', ([accountOwner1, accountOwner
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -188,7 +186,7 @@ contract('Long Put Spread Option closed ITM flow', ([accountOwner1, accountOwner
           vaultId: vaultCounter2,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,
@@ -261,7 +259,7 @@ contract('Long Put Spread Option closed ITM flow', ([accountOwner1, accountOwner
           vaultId: vaultCounter1,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,

--- a/test/integration-tests/longPutExpireOtm.test.ts
+++ b/test/integration-tests/longPutExpireOtm.test.ts
@@ -70,8 +70,6 @@ contract('Long Put Spread Option expires Otm flow', ([accountOwner1, nakedBuyer,
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -194,7 +192,7 @@ contract('Long Put Spread Option expires Otm flow', ([accountOwner1, nakedBuyer,
             vaultId: vaultCounter2,
             amount: '0',
             index: '0',
-            data: openVaultBytes,
+            data: ZERO_ADDR,
           },
           {
             actionType: ActionType.MintShortOption,
@@ -232,7 +230,7 @@ contract('Long Put Spread Option expires Otm flow', ([accountOwner1, nakedBuyer,
             vaultId: vaultCounter1,
             amount: '0',
             index: '0',
-            data: openVaultBytes,
+            data: ZERO_ADDR,
           },
           {
             actionType: ActionType.MintShortOption,

--- a/test/integration-tests/longPutPreExpiry.test.ts
+++ b/test/integration-tests/longPutPreExpiry.test.ts
@@ -70,8 +70,6 @@ contract('Long Put Spread Option closed before expiry flow', ([accountOwner1, bu
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -188,7 +186,7 @@ contract('Long Put Spread Option closed before expiry flow', ([accountOwner1, bu
           vaultId: vaultCounter2,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,
@@ -261,7 +259,7 @@ contract('Long Put Spread Option closed before expiry flow', ([accountOwner1, bu
           vaultId: vaultCounter1,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,

--- a/test/integration-tests/nakedCallExpireItm.test.ts
+++ b/test/integration-tests/nakedCallExpireItm.test.ts
@@ -66,8 +66,6 @@ contract('Naked Call Option expires Itm flow', ([accountOwner1, buyer]) => {
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -155,7 +153,7 @@ contract('Naked Call Option expires Itm flow', ([accountOwner1, buyer]) => {
           vaultId: vaultCounter,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,

--- a/test/integration-tests/nakedCallExpireOtm.test.ts
+++ b/test/integration-tests/nakedCallExpireOtm.test.ts
@@ -66,8 +66,6 @@ contract('Naked Call Option expires Otm flow', ([accountOwner1, buyer]) => {
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -156,7 +154,7 @@ contract('Naked Call Option expires Otm flow', ([accountOwner1, buyer]) => {
           vaultId: vaultCounter,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,

--- a/test/integration-tests/nakedCallPreExpiry.test.ts
+++ b/test/integration-tests/nakedCallPreExpiry.test.ts
@@ -66,8 +66,6 @@ contract('Naked Call Option closed before expiry flow', ([accountOwner1]) => {
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -184,7 +182,7 @@ contract('Naked Call Option closed before expiry flow', ([accountOwner1]) => {
           vaultId: vaultCounter,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,

--- a/test/integration-tests/nakedPutExpireITM.test.ts
+++ b/test/integration-tests/nakedPutExpireITM.test.ts
@@ -66,8 +66,6 @@ contract('Naked Put Option expires Itm flow', ([accountOwner1, buyer]) => {
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -157,7 +155,7 @@ contract('Naked Put Option expires Itm flow', ([accountOwner1, buyer]) => {
           vaultId: vaultCounter,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,

--- a/test/integration-tests/nakedPutExpireOTM.test.ts
+++ b/test/integration-tests/nakedPutExpireOTM.test.ts
@@ -66,8 +66,6 @@ contract('Naked Put Option expires Otm flow', ([accountOwner1, buyer]) => {
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -156,7 +154,7 @@ contract('Naked Put Option expires Otm flow', ([accountOwner1, buyer]) => {
           vaultId: vaultCounter,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,

--- a/test/integration-tests/nakedPutPreExpiry.test.ts
+++ b/test/integration-tests/nakedPutPreExpiry.test.ts
@@ -66,8 +66,6 @@ contract('Naked Put Option closed before expiry flow', ([accountOwner1]) => {
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -185,7 +183,7 @@ contract('Naked Put Option closed before expiry flow', ([accountOwner1]) => {
           vaultId: vaultCounter,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,

--- a/test/integration-tests/open-markets.test.ts
+++ b/test/integration-tests/open-markets.test.ts
@@ -66,8 +66,6 @@ contract('OTokenFactory + Otoken: Cloning of real otoken instances.', ([owner, u
   const isPut = true
   let expiry: number
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('Deploy addressBook, otoken logic, whitelist, Factory contract', async () => {
     expiry = createValidExpiry(Number(await time.latest()), 100)
     usdc = await MockERC20.new('USDC', 'USDC', 6)
@@ -245,7 +243,7 @@ contract('OTokenFactory + Otoken: Cloning of real otoken instances.', ([owner, u
           vaultId: vaultCounter,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,

--- a/test/integration-tests/rollover.test.ts
+++ b/test/integration-tests/rollover.test.ts
@@ -70,8 +70,6 @@ contract('Rollover Naked Put Option flow', ([accountOwner1, accountOperator1, bu
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     let now = (await time.latest()).toNumber()
     expiry1 = createValidExpiry(now, 30)
@@ -212,7 +210,7 @@ contract('Rollover Naked Put Option flow', ([accountOwner1, accountOperator1, bu
           vaultId: vaultCounter,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,
@@ -428,7 +426,7 @@ contract('Rollover Naked Put Option flow', ([accountOwner1, accountOperator1, bu
             vaultId: vaultCounter,
             amount: '0',
             index: '0',
-            data: openVaultBytes,
+            data: ZERO_ADDR,
           },
           {
             actionType: ActionType.MintShortOption,

--- a/test/integration-tests/shortCallSpreadExpireItm.test.ts
+++ b/test/integration-tests/shortCallSpreadExpireItm.test.ts
@@ -70,8 +70,6 @@ contract('Short Call Spread Option expires Itm flow', ([accountOwner1, nakedBuye
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -195,7 +193,7 @@ contract('Short Call Spread Option expires Itm flow', ([accountOwner1, nakedBuye
             vaultId: vaultCounter2,
             amount: '0',
             index: '0',
-            data: openVaultBytes,
+            data: ZERO_ADDR,
           },
           {
             actionType: ActionType.MintShortOption,
@@ -233,7 +231,7 @@ contract('Short Call Spread Option expires Itm flow', ([accountOwner1, nakedBuye
             vaultId: vaultCounter1,
             amount: '0',
             index: '0',
-            data: openVaultBytes,
+            data: ZERO_ADDR,
           },
           {
             actionType: ActionType.MintShortOption,

--- a/test/integration-tests/shortCallSpreadExpireOtm.test.ts
+++ b/test/integration-tests/shortCallSpreadExpireOtm.test.ts
@@ -70,8 +70,6 @@ contract('Short Call Spread Option expires Otm flow', ([accountOwner1, nakedBuye
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -195,7 +193,7 @@ contract('Short Call Spread Option expires Otm flow', ([accountOwner1, nakedBuye
             vaultId: vaultCounter2,
             amount: '0',
             index: '0',
-            data: openVaultBytes,
+            data: ZERO_ADDR,
           },
           {
             actionType: ActionType.MintShortOption,
@@ -233,7 +231,7 @@ contract('Short Call Spread Option expires Otm flow', ([accountOwner1, nakedBuye
             vaultId: vaultCounter1,
             amount: '0',
             index: '0',
-            data: openVaultBytes,
+            data: ZERO_ADDR,
           },
           {
             actionType: ActionType.MintShortOption,

--- a/test/integration-tests/shortCallSpreadPreExpiry.test.ts
+++ b/test/integration-tests/shortCallSpreadPreExpiry.test.ts
@@ -70,8 +70,6 @@ contract('Short Call Spread Option closed before expiry flow', ([accountOwner1, 
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -192,7 +190,7 @@ contract('Short Call Spread Option closed before expiry flow', ([accountOwner1, 
           vaultId: vaultCounter2,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,
@@ -265,7 +263,7 @@ contract('Short Call Spread Option closed before expiry flow', ([accountOwner1, 
           vaultId: vaultCounter1,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,

--- a/test/integration-tests/shortPutSpreadExpireItm.test.ts
+++ b/test/integration-tests/shortPutSpreadExpireItm.test.ts
@@ -70,8 +70,6 @@ contract('Short Put Spread Option expires Itm flow', ([accountOwner1, nakedBuyer
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -194,7 +192,7 @@ contract('Short Put Spread Option expires Itm flow', ([accountOwner1, nakedBuyer
             vaultId: vaultCounter2,
             amount: '0',
             index: '0',
-            data: openVaultBytes,
+            data: ZERO_ADDR,
           },
           {
             actionType: ActionType.MintShortOption,
@@ -232,7 +230,7 @@ contract('Short Put Spread Option expires Itm flow', ([accountOwner1, nakedBuyer
             vaultId: vaultCounter1,
             amount: '0',
             index: '0',
-            data: openVaultBytes,
+            data: ZERO_ADDR,
           },
           {
             actionType: ActionType.MintShortOption,

--- a/test/integration-tests/shortPutSpreadExpireOtm.test.ts
+++ b/test/integration-tests/shortPutSpreadExpireOtm.test.ts
@@ -70,8 +70,6 @@ contract('Short Put Spread Option expires Otm flow', ([accountOwner1, nakedBuyer
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -194,7 +192,7 @@ contract('Short Put Spread Option expires Otm flow', ([accountOwner1, nakedBuyer
             vaultId: vaultCounter2,
             amount: '0',
             index: '0',
-            data: openVaultBytes,
+            data: ZERO_ADDR,
           },
           {
             actionType: ActionType.MintShortOption,
@@ -232,7 +230,7 @@ contract('Short Put Spread Option expires Otm flow', ([accountOwner1, nakedBuyer
             vaultId: vaultCounter1,
             amount: '0',
             index: '0',
-            data: openVaultBytes,
+            data: ZERO_ADDR,
           },
           {
             actionType: ActionType.MintShortOption,

--- a/test/integration-tests/shortPutSpreadPreExpiry.test.ts
+++ b/test/integration-tests/shortPutSpreadPreExpiry.test.ts
@@ -70,8 +70,6 @@ contract('Short Put Spread Option closed before expiry flow', ([accountOwner1, n
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -191,7 +189,7 @@ contract('Short Put Spread Option closed before expiry flow', ([accountOwner1, n
           vaultId: vaultCounter2,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,
@@ -264,7 +262,7 @@ contract('Short Put Spread Option closed before expiry flow', ([accountOwner1, n
           vaultId: vaultCounter1,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,

--- a/test/integration-tests/yieldFarming.test.ts
+++ b/test/integration-tests/yieldFarming.test.ts
@@ -72,8 +72,6 @@ contract('Yield Farming: Naked Put Option closed before expiry flow', ([admin, a
   const usdcDecimals = 6
   const wethDecimals = 18
 
-  const openVaultBytes = web3.eth.abi.encodeParameter('uint256', 0)
-
   before('set up contracts', async () => {
     const now = (await time.latest()).toNumber()
     expiry = createValidExpiry(now, 30)
@@ -162,7 +160,7 @@ contract('Yield Farming: Naked Put Option closed before expiry flow', ([admin, a
           vaultId: vaultCounter,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,
@@ -314,7 +312,7 @@ contract('Yield Farming: Naked Put Option closed before expiry flow', ([admin, a
           vaultId: vaultCounter,
           amount: '0',
           index: '0',
-          data: openVaultBytes,
+          data: ZERO_ADDR,
         },
         {
           actionType: ActionType.MintShortOption,


### PR DESCRIPTION
# Task: undo vault type changes in old integration tests

## High Level Description

This PR remove the changes in the old integration tests where I added vault type for every OpenVault action.
We don't need that as the open vault action is backward compatible.

### Code

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?

### Documentation

- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
