### PR TITLE
Merge setProductTimeToExpiry() & setTimeToExpiryValue() into setUpperBoundValues()

### DIFF
--- a/contracts/MarginCalculator.sol
+++ b/contracts/MarginCalculator.sol
@@ -153,42 +153,42 @@ contract MarginCalculator is Ownable {
         }
     }
 
-    /**
-     * @notice set new time to expiry for specific product
-     * @dev can only be called by owner
-     * @param _underlying otoken underlying asset
-     * @param _strike otoken strike asset
-     * @param _collateral otoken collateral asset
-     * @param _isPut otoken type
-     * @param _timeToExpiry option time to expiry timestamp
-     */
-    function setProductTimeToExpiry(
-        address _underlying,
-        address _strike,
-        address _collateral,
-        bool _isPut,
-        uint256 _timeToExpiry
-    ) external onlyOwner {
-        // get product hash
-        bytes32 productHash = _getProductHash(_underlying, _strike, _collateral, _isPut);
-        // get array of expiries
-        uint256[] storage expiryArray = productTimeToExpiry[productHash];
+    // /**
+    //  * @notice set new time to expiry for specific product
+    //  * @dev can only be called by owner
+    //  * @param _underlying otoken underlying asset
+    //  * @param _strike otoken strike asset
+    //  * @param _collateral otoken collateral asset
+    //  * @param _isPut otoken type
+    //  * @param _timeToExpiry option time to expiry timestamp
+    //  */
+    // function setProductTimeToExpiry(
+    //     address _underlying,
+    //     address _strike,
+    //     address _collateral,
+    //     bool _isPut,
+    //     uint256 _timeToExpiry
+    // ) external onlyOwner {
+    //     // get product hash
+    //     bytes32 productHash = _getProductHash(_underlying, _strike, _collateral, _isPut);
+    //     // get array of expiries
+    //     uint256[] storage expiryArray = productTimeToExpiry[productHash];
 
-        // check that this is the first expiry to set, if not the last expiry should be less than the new one to insert (to make sure the array stay in order)
-        require(
-            (expiryArray.length == 0) || (_timeToExpiry > expiryArray[expiryArray.length.sub(1)]),
-            "MarginCalculator: expiry array is not in order"
-        );
+    //     // check that this is the first expiry to set, if not the last expiry should be less than the new one to insert (to make sure the array stay in order)
+    //     require(
+    //         (expiryArray.length == 0) || (_timeToExpiry > expiryArray[expiryArray.length.sub(1)]),
+    //         "MarginCalculator: expiry array is not in order"
+    //     );
 
-        // check that this time to expiry have an upper bound value (setTimeToExpiryValue() should be called before this)
-        require(
-            timeToExpiryValue[productHash][_timeToExpiry] != 0,
-            "MarginCalculator: no expiry upper bound value found"
-        );
+    //     // check that this time to expiry have an upper bound value (setTimeToExpiryValue() should be called before this)
+    //     require(
+    //         timeToExpiryValue[productHash][_timeToExpiry] != 0,
+    //         "MarginCalculator: no expiry upper bound value found"
+    //     );
 
-        // add new time to expiry to array
-        expiryArray.push(_timeToExpiry);
-    }
+    //     // add new time to expiry to array
+    //     expiryArray.push(_timeToExpiry);
+    // }
 
     /**
      * @notice set option upper bound value for specific time to expiry (1e27)
@@ -200,7 +200,7 @@ contract MarginCalculator is Ownable {
      * @param _timeToExpiry option time to expiry timestamp
      * @param _value upper bound value
      */
-    function setTimeToExpiryValue(
+    function updateUpperBoundValue(
         address _underlying,
         address _strike,
         address _collateral,

--- a/contracts/MarginCalculator.sol
+++ b/contracts/MarginCalculator.sol
@@ -176,7 +176,9 @@ contract MarginCalculator is Ownable {
 
         bytes32 productHash = _getProductHash(_underlying, _strike, _collateral, _isPut);
 
-        // add new upper bound value for this product at specific time to expiry
+        require(timeToExpiryValue[productHash][_timeToExpiry] != 0, "MarginCalculator: upper bound value not found");
+
+        // update upper bound value for the time to expiry
         timeToExpiryValue[productHash][_timeToExpiry] = _value;
     }
 

--- a/contracts/MarginCalculator.sol
+++ b/contracts/MarginCalculator.sol
@@ -153,43 +153,6 @@ contract MarginCalculator is Ownable {
         }
     }
 
-    // /**
-    //  * @notice set new time to expiry for specific product
-    //  * @dev can only be called by owner
-    //  * @param _underlying otoken underlying asset
-    //  * @param _strike otoken strike asset
-    //  * @param _collateral otoken collateral asset
-    //  * @param _isPut otoken type
-    //  * @param _timeToExpiry option time to expiry timestamp
-    //  */
-    // function setProductTimeToExpiry(
-    //     address _underlying,
-    //     address _strike,
-    //     address _collateral,
-    //     bool _isPut,
-    //     uint256 _timeToExpiry
-    // ) external onlyOwner {
-    //     // get product hash
-    //     bytes32 productHash = _getProductHash(_underlying, _strike, _collateral, _isPut);
-    //     // get array of expiries
-    //     uint256[] storage expiryArray = productTimeToExpiry[productHash];
-
-    //     // check that this is the first expiry to set, if not the last expiry should be less than the new one to insert (to make sure the array stay in order)
-    //     require(
-    //         (expiryArray.length == 0) || (_timeToExpiry > expiryArray[expiryArray.length.sub(1)]),
-    //         "MarginCalculator: expiry array is not in order"
-    //     );
-
-    //     // check that this time to expiry have an upper bound value (setTimeToExpiryValue() should be called before this)
-    //     require(
-    //         timeToExpiryValue[productHash][_timeToExpiry] != 0,
-    //         "MarginCalculator: no expiry upper bound value found"
-    //     );
-
-    //     // add new time to expiry to array
-    //     expiryArray.push(_timeToExpiry);
-    // }
-
     /**
      * @notice set option upper bound value for specific time to expiry (1e27)
      * @dev can only be called by owner

--- a/test/integration-tests/nakedMarginCallPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginCallPreExpiry.test.ts
@@ -375,6 +375,7 @@ contract('Naked margin: call position pre expiry', ([owner, accountOwner1, liqui
       const isLiquidatable = await controllerProxy.isLiquidatable(accountOwner1, vaultCounter.toString(), roundId)
 
       assert.equal(isLiquidatable[0], true, 'Vault liquidation state mismatch')
+      assert.isTrue(new BigNumber(isLiquidatable[1]).isGreaterThan(0), 'Liquidation price is equal to zero')
 
       const liquidateArgs = [
         {
@@ -565,6 +566,7 @@ contract('Naked margin: call position pre expiry', ([owner, accountOwner1, liqui
       const isLiquidatable = await controllerProxy.isLiquidatable(accountOwner1, vaultCounter.toString(), roundId)
 
       assert.equal(isLiquidatable[0], true, 'Vault liquidation state mismatch')
+      assert.isTrue(new BigNumber(isLiquidatable[1]).isGreaterThan(0), 'Liquidation price is equal to zero')
 
       const mintLiquidateArgs = [
         {

--- a/test/integration-tests/nakedMarginCallPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginCallPreExpiry.test.ts
@@ -403,7 +403,7 @@ contract('Naked margin: call position pre expiry', ([owner, accountOwner1, liqui
           vaultAfterLiquidation.collateralAmounts[0],
           new BigNumber(vaultBeforeLiquidation.collateralAmounts[0]).minus(isLiquidatable[1]),
         )
-          .dividedBy(wethDecimals)
+          .dividedBy(10 ** wethDecimals)
           .toNumber(),
         errorDelta,
         'Vault collateral mismatch after liquidation',
@@ -628,7 +628,7 @@ contract('Naked margin: call position pre expiry', ([owner, accountOwner1, liqui
           vaultAfterLiquidation.collateralAmounts[0],
           new BigNumber(vaultBeforeLiquidation.collateralAmounts[0]).minus(isLiquidatable[1]),
         )
-          .dividedBy(wethDecimals)
+          .dividedBy(10 ** wethDecimals)
           .toNumber(),
         errorDelta,
         'Vault collateral mismatch after liquidation',

--- a/test/integration-tests/nakedMarginCallPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginCallPreExpiry.test.ts
@@ -131,22 +131,10 @@ contract('Naked margin: call position pre expiry', ([owner, accountOwner1, liqui
     await calculator.setSpotShock(weth.address, usdc.address, weth.address, isPut, productSpotShockValue)
     await calculator.setOracleDeviation(oracleDeviationValue, {from: owner})
     await calculator.setCollateralDust(weth.address, wethDust, {from: owner})
-    for (let i = 0; i < expiryToValue.length; i++) {
-      // set for put product
-      await calculator.setTimeToExpiryValue(
-        weth.address,
-        usdc.address,
-        weth.address,
-        isPut,
-        timeToExpiry[i],
-        expiryToValue[i],
-        {from: owner},
-      )
-      await calculator.setProductTimeToExpiry(weth.address, usdc.address, weth.address, isPut, timeToExpiry[i], {
-        from: owner,
-      })
-    }
-
+    // set product upper bound values
+    await calculator.setUpperBoundValues(weth.address, usdc.address, weth.address, isPut, timeToExpiry, expiryToValue, {
+      from: owner,
+    })
     // mint usdc to user
     await weth.mint(accountOwner1, createTokenAmount(10000, wethDecimals))
     await weth.mint(liquidator, createTokenAmount(10000, wethDecimals))

--- a/test/integration-tests/nakedMarginCallPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginCallPreExpiry.test.ts
@@ -370,7 +370,7 @@ contract('Naked margin: call position pre expiry', ([owner, accountOwner1, liqui
       await oracle.setChainlinkRoundData(weth.address, roundId, scaledUnderlyingPrice, (await time.latest()).toString())
 
       // advance time
-      await time.increase(600)
+      await time.increase(1500)
 
       const isLiquidatable = await controllerProxy.isLiquidatable(accountOwner1, vaultCounter.toString(), roundId)
 
@@ -409,9 +409,11 @@ contract('Naked margin: call position pre expiry', ([owner, accountOwner1, liqui
         errorDelta,
         'Vault collateral mismatch after liquidation',
       )
-      assert.equal(
-        liquidatorCollateralBalanceAfter.toString(),
-        liquidatorCollateralBalanceBefore.plus(isLiquidatable[1].toString()).toString(),
+      assert.isAtMost(
+        calcRelativeDiff(liquidatorCollateralBalanceBefore.plus(isLiquidatable[1]), liquidatorCollateralBalanceAfter)
+          .dividedBy(10 ** wethDecimals)
+          .toNumber(),
+        errorDelta,
         'Liquidator collateral balance mismatch after liquidation',
       )
     })
@@ -635,20 +637,18 @@ contract('Naked margin: call position pre expiry', ([owner, accountOwner1, liqui
         errorDelta,
         'Vault collateral mismatch after liquidation',
       )
-      assert.equal(
-        liquidatorWethAfter.toString(),
-        liquidatorWethBefore
-          .minus(collateralToDeposit)
-          .plus(isLiquidatable[1])
-          .toString(),
+      assert.isAtMost(
+        calcRelativeDiff(liquidatorWethBefore.minus(collateralToDeposit).plus(isLiquidatable[1]), liquidatorWethAfter)
+          .dividedBy(10 ** wethDecimals)
+          .toNumber(),
+        errorDelta,
         'Liquidator collateral balance mismatch after liquidation',
       )
-      assert.equal(
-        poolWethAfter
-          .plus(isLiquidatable[1].toString())
-          .minus(collateralToDeposit.toString())
-          .toString(),
-        poolWethBefore.toString(),
+      assert.isAtMost(
+        calcRelativeDiff(poolWethAfter.minus(collateralToDeposit).plus(isLiquidatable[1]), poolWethBefore)
+          .dividedBy(10 ** wethDecimals)
+          .toNumber(),
+        errorDelta,
         'Pool balance after openining position mismatch',
       )
       assert.equal(

--- a/test/integration-tests/nakedMarginPutPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginPutPreExpiry.test.ts
@@ -410,9 +410,11 @@ contract('Naked margin: put position pre expiry', ([owner, accountOwner1, buyer1
         errorDelta,
         'Vault collateral mismatch after liquidation',
       )
-      assert.equal(
-        liquidatorCollateralBalanceAfter.toString(),
-        liquidatorCollateralBalanceBefore.plus(isLiquidatable[1].toString()).toString(),
+      assert.isAtMost(
+        calcRelativeDiff(liquidatorCollateralBalanceBefore.plus(isLiquidatable[1]), liquidatorCollateralBalanceAfter)
+          .dividedBy(10 ** wethDecimals)
+          .toNumber(),
+        errorDelta,
         'Liquidator collateral balance mismatch after liquidation',
       )
     })

--- a/test/integration-tests/nakedMarginPutPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginPutPreExpiry.test.ts
@@ -131,22 +131,10 @@ contract('Naked margin: put position pre expiry', ([owner, accountOwner1, buyer1
     await calculator.setSpotShock(weth.address, usdc.address, usdc.address, isPut, productSpotShockValue)
     await calculator.setOracleDeviation(oracleDeviationValue, {from: owner})
     await calculator.setCollateralDust(usdc.address, usdcDust, {from: owner})
-    for (let i = 0; i < expiryToValue.length; i++) {
-      // set for put product
-      await calculator.setTimeToExpiryValue(
-        weth.address,
-        usdc.address,
-        usdc.address,
-        isPut,
-        timeToExpiry[i],
-        expiryToValue[i],
-        {from: owner},
-      )
-      await calculator.setProductTimeToExpiry(weth.address, usdc.address, usdc.address, isPut, timeToExpiry[i], {
-        from: owner,
-      })
-    }
-
+    // set product upper bound values
+    await calculator.setUpperBoundValues(weth.address, usdc.address, usdc.address, isPut, timeToExpiry, expiryToValue, {
+      from: owner,
+    })
     // mint usdc to user
     await usdc.mint(accountOwner1, createTokenAmount(10000, usdcDecimals))
     await usdc.mint(liquidator, createTokenAmount(10000, usdcDecimals))

--- a/test/integration-tests/nakedMarginPutPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginPutPreExpiry.test.ts
@@ -403,7 +403,9 @@ contract('Naked margin: put position pre expiry', ([owner, accountOwner1, buyer1
         calcRelativeDiff(
           vaultAfterLiquidation.collateralAmounts[0],
           new BigNumber(vaultBeforeLiquidation.collateralAmounts[0]).minus(isLiquidatable[1]),
-        ).toNumber(),
+        )
+          .dividedBy(10 ** usdcDecimals)
+          .toNumber(),
         errorDelta,
         'Vault collateral mismatch after liquidation',
       )
@@ -626,7 +628,9 @@ contract('Naked margin: put position pre expiry', ([owner, accountOwner1, buyer1
         calcRelativeDiff(
           vaultAfterLiquidation.collateralAmounts[0],
           new BigNumber(vaultBeforeLiquidation.collateralAmounts[0]).minus(isLiquidatable[1]),
-        ).toNumber(),
+        )
+          .dividedBy(10 ** usdcDecimals)
+          .toNumber(),
         errorDelta,
         'Vault collateral mismatch after liquidation',
       )

--- a/test/integration-tests/nakedMarginPutPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginPutPreExpiry.test.ts
@@ -376,6 +376,7 @@ contract('Naked margin: put position pre expiry', ([owner, accountOwner1, buyer1
       const isLiquidatable = await controllerProxy.isLiquidatable(accountOwner1, vaultCounter.toString(), roundId)
 
       assert.equal(isLiquidatable[0], true, 'Vault liquidation state mismatch')
+      assert.isTrue(new BigNumber(isLiquidatable[1]).isGreaterThan(0), 'Liquidation price is equal to zero')
 
       const liquidateArgs = [
         {
@@ -566,6 +567,7 @@ contract('Naked margin: put position pre expiry', ([owner, accountOwner1, buyer1
       const isLiquidatable = await controllerProxy.isLiquidatable(accountOwner1, vaultCounter.toString(), roundId)
 
       assert.equal(isLiquidatable[0], true, 'Vault liquidation state mismatch')
+      assert.isTrue(new BigNumber(isLiquidatable[1]).isGreaterThan(0), 'Liquidation price is equal to zero')
 
       const mintLiquidateArgs = [
         {

--- a/test/unit-tests/controllerNakedMargin.test.ts
+++ b/test/unit-tests/controllerNakedMargin.test.ts
@@ -383,6 +383,7 @@ contract('Controller: naked margin', ([owner, accountOwner1, liquidator]) => {
       const isLiquidatable = await controllerProxy.isLiquidatable(accountOwner1, vaultCounter.toString(), roundId)
 
       assert.equal(isLiquidatable[0], true, 'Vault liquidation state mismatch')
+      assert.isTrue(new BigNumber(isLiquidatable[1]).isGreaterThan(0), 'Liquidation price is equal to zero')
 
       const vaultBeforeLiquidation = (await controllerProxy.getVault(accountOwner1, vaultCounter.toString()))[0]
 
@@ -572,6 +573,7 @@ contract('Controller: naked margin', ([owner, accountOwner1, liquidator]) => {
       const isLiquidatable = await controllerProxy.isLiquidatable(accountOwner1, vaultCounter.toString(), roundId)
 
       assert.equal(isLiquidatable[0], true, 'Vault liquidation state mismatch')
+      assert.isTrue(new BigNumber(isLiquidatable[1]).isGreaterThan(0), 'Liquidation price is equal to zero')
 
       const vaultBeforeLiquidation = (await controllerProxy.getVault(accountOwner1, vaultCounter.toString()))[0]
 
@@ -759,6 +761,7 @@ contract('Controller: naked margin', ([owner, accountOwner1, liquidator]) => {
       const isLiquidatable = await controllerProxy.isLiquidatable(accountOwner1, vaultCounter.toString(), roundId)
 
       assert.equal(isLiquidatable[0], true, 'Vault liquidation state mismatch')
+      assert.isTrue(new BigNumber(isLiquidatable[1]).isGreaterThan(0), 'Liquidation price is equal to zero')
 
       const vaultBeforeLiquidation = (await controllerProxy.getVault(accountOwner1, vaultCounter.toString()))[0]
 

--- a/test/unit-tests/controllerNakedMargin.test.ts
+++ b/test/unit-tests/controllerNakedMargin.test.ts
@@ -149,36 +149,13 @@ contract('Controller: naked margin', ([owner, accountOwner1, liquidator]) => {
     await calculator.setCollateralDust(weth.address, wethDust, {from: owner})
     // set USDC dust amount
     await calculator.setCollateralDust(usdc.address, usdcDust, {from: owner})
-    // set time to expiry and each upper bound value
-    for (let i = 0; i < expiryToValue.length; i++) {
-      // set for put product
-      await calculator.setTimeToExpiryValue(
-        weth.address,
-        usdc.address,
-        usdc.address,
-        true,
-        timeToExpiry[i],
-        expiryToValue[i],
-        {from: owner},
-      )
-      await calculator.setProductTimeToExpiry(weth.address, usdc.address, usdc.address, true, timeToExpiry[i], {
-        from: owner,
-      })
-
-      // set for call product
-      await calculator.setTimeToExpiryValue(
-        weth.address,
-        usdc.address,
-        weth.address,
-        false,
-        timeToExpiry[i],
-        expiryToValue[i],
-        {from: owner},
-      )
-      await calculator.setProductTimeToExpiry(weth.address, usdc.address, weth.address, false, timeToExpiry[i], {
-        from: owner,
-      })
-    }
+    // set product upper bound values
+    await calculator.setUpperBoundValues(weth.address, usdc.address, usdc.address, true, timeToExpiry, expiryToValue, {
+      from: owner,
+    })
+    await calculator.setUpperBoundValues(weth.address, usdc.address, weth.address, false, timeToExpiry, expiryToValue, {
+      from: owner,
+    })
   })
 
   describe('settle naked margin vault', async () => {

--- a/test/unit-tests/liquidations.test.ts
+++ b/test/unit-tests/liquidations.test.ts
@@ -81,35 +81,9 @@ contract('MarginCalculator: liquidation', ([owner, random]) => {
     await calculator.setSpotShock(weth.address, usdc.address, usdc.address, true, productSpotShockValue)
     await calculator.setSpotShock(weth.address, usdc.address, weth.address, false, productSpotShockValue)
     // set time to expiry and each upper bound value
-    for (let i = 0; i < expiryToValue.length; i++) {
-      // set for put product
-      await calculator.setTimeToExpiryValue(
-        weth.address,
-        usdc.address,
-        usdc.address,
-        true,
-        timeToExpiry[i],
-        expiryToValue[i],
-        {from: owner},
-      )
-      await calculator.setProductTimeToExpiry(weth.address, usdc.address, usdc.address, true, timeToExpiry[i], {
-        from: owner,
-      })
-
-      // set for call product
-      await calculator.setTimeToExpiryValue(
-        weth.address,
-        usdc.address,
-        weth.address,
-        false,
-        timeToExpiry[i],
-        expiryToValue[i],
-        {from: owner},
-      )
-      await calculator.setProductTimeToExpiry(weth.address, usdc.address, weth.address, false, timeToExpiry[i], {
-        from: owner,
-      })
-    }
+    await calculator.setUpperBoundValues(weth.address, usdc.address, usdc.address, true, timeToExpiry, expiryToValue, {
+      from: owner,
+    })
   })
 
   describe('check if vault is liquidatable', () => {

--- a/test/unit-tests/marginCalculatorNakedMargin.test.ts
+++ b/test/unit-tests/marginCalculatorNakedMargin.test.ts
@@ -104,11 +104,20 @@ contract('MarginCalculator: partial collateralization', ([owner, random]) => {
     })
 
     it('should revert setting collateral dust from address other than owner', async () => {
-      const wethDust = scaleNum(0, wethDecimals)
+      const wethDust = scaleNum(1, wethDecimals)
 
       await expectRevert(
         calculator.setCollateralDust(weth.address, wethDust, {from: random}),
         'Ownable: caller is not the owner',
+      )
+    })
+
+    it('should revert setting collateral dust amount equal to zero', async () => {
+      const wethDust = scaleNum(0, wethDecimals)
+
+      await expectRevert(
+        calculator.setCollateralDust(weth.address, wethDust, {from: owner}),
+        'MarginCalculator: dust amount should be greater than zero',
       )
     })
   })
@@ -223,6 +232,18 @@ contract('MarginCalculator: partial collateralization', ([owner, random]) => {
         'MarginCalculator: expiry array is not in order',
       )
     })
+
+    it('should revert setting product time to expiry when new expiry array is not oredered', async () => {
+      const timeToExpiry = [60 * 24 * 21, 60 * 24 * 14]
+      const upperBoundValue = [scaleNum(0.2, 27), scaleNum(0.2, 27)]
+
+      await expectRevert(
+        calculator.setUpperBoundValues(weth.address, usdc.address, usdc.address, true, timeToExpiry, upperBoundValue, {
+          from: owner,
+        }),
+        'MarginCalculator: time should be in order',
+      )
+    })
   })
 
   describe('Spot shock value', async () => {
@@ -232,6 +253,15 @@ contract('MarginCalculator: partial collateralization', ([owner, random]) => {
       await expectRevert(
         calculator.setSpotShock(weth.address, usdc.address, usdc.address, true, spotShockValue, {from: random}),
         'Ownable: caller is not the owner',
+      )
+    })
+
+    it('should revert setting spot shock value when value is equal to zero', async () => {
+      const spotShockValue = scaleNum(0, 27)
+
+      await expectRevert(
+        calculator.setSpotShock(weth.address, usdc.address, usdc.address, true, spotShockValue, {from: owner}),
+        'MarginCalculator: invalid spot shock value',
       )
     })
 

--- a/test/unit-tests/marginCalculatorNakedMargin.test.ts
+++ b/test/unit-tests/marginCalculatorNakedMargin.test.ts
@@ -132,17 +132,28 @@ contract('MarginCalculator: partial collateralization', ([owner, random]) => {
       )
     })
 
-    // it('should revert setting time to expiry value when value is equal to zero', async () => {
-    //   const upperBoundValue = scaleNum(0, 27)
-    //   const timeToExpiry = 60 * 24 * 7
+    it('should revert setting upper bound values when time to expiry array length is equal to zero', async () => {
+      const upperBoundValue = scaleNum(0.03, 27)
 
-    //   await expectRevert(
-    //     calculator.setUpperBoundValues(weth.address, usdc.address, usdc.address, true, [timeToExpiry], [upperBoundValue], {
-    //       from: owner,
-    //     }),
-    //     'MarginCalculator: invalid option upper bound value',
-    //   )
-    // })
+      await expectRevert(
+        calculator.setUpperBoundValues(weth.address, usdc.address, usdc.address, true, [], [upperBoundValue], {
+          from: owner,
+        }),
+        'MarginCalculator: invalid times to expiry array',
+      )
+    })
+
+    it('should revert setting upper bound values when time to expiry and value arrays length are not equal', async () => {
+      const upperBoundValue = [scaleNum(0.03, 27), scaleNum(0.05, 27)]
+      const timeToExpiry = [60 * 24 * 7]
+
+      await expectRevert(
+        calculator.setUpperBoundValues(weth.address, usdc.address, usdc.address, true, timeToExpiry, upperBoundValue, {
+          from: owner,
+        }),
+        'MarginCalculator: invalid values array',
+      )
+    })
 
     it('should revert setting product upper bound value when value is equal to zero', async () => {
       const timeToExpiry = 60 * 24 * 7

--- a/test/unit-tests/marginCalculatorNakedMargin.test.ts
+++ b/test/unit-tests/marginCalculatorNakedMargin.test.ts
@@ -333,6 +333,7 @@ contract('MarginCalculator: partial collateralization', ([owner, random]) => {
 
       // set product spot shock value
       await calculator.setSpotShock(weth.address, usdc.address, usdc.address, true, productSpotShockValue)
+      await calculator.setSpotShock(weth.address, usdc.address, weth.address, false, productSpotShockValue)
 
       // set product upper bound values
       await calculator.setUpperBoundValues(
@@ -340,6 +341,17 @@ contract('MarginCalculator: partial collateralization', ([owner, random]) => {
         usdc.address,
         weth.address,
         false,
+        timeToExpiry,
+        expiryToValue,
+        {
+          from: owner,
+        },
+      )
+      await calculator.setUpperBoundValues(
+        weth.address,
+        usdc.address,
+        usdc.address,
+        true,
         timeToExpiry,
         expiryToValue,
         {


### PR DESCRIPTION
# Task: Merge setProductTimeToExpiry() & setTimeToExpiryValue() into setUpperBoundValues()

## High Level Description

- Remove `setProductTimeToExpiry()` & `setTimeToExpiryValue`
- Add `setUpperBoundValues()` that allow adding many times and p(t) in the same tx
- Add `updateUpperBoundValue()` that allow updating the value for a specific time to expiry

### Code

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?

### Documentation

- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
