### PR TITLE
Add donate feature

### DIFF
--- a/contracts/Controller.sol
+++ b/contracts/Controller.sol
@@ -262,6 +262,12 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
         _refreshConfigInternal();
     }
 
+    /**
+     * @notice send asset amount to margin pool
+     * @dev use donate() instead of direct transfer() to store the balance in assetBalance
+     * @param _asset asset address
+     * @param _amount amount to donate to pool
+     */
     function donate(address _asset, uint256 _amount) external {
         pool.transferToPool(_asset, msg.sender, _amount);
 

--- a/contracts/Controller.sol
+++ b/contracts/Controller.sol
@@ -158,6 +158,8 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
     event SystemFullyPaused(bool isPaused);
     /// @notice emits an event when the call action restriction changes
     event CallRestricted(bool isRestricted);
+    /// @notice emits an event when a donation transfer executed
+    event Donated(address indexed donator, address indexed asset, uint256 amount);
 
     /**
      * @notice modifier to check if the system is not partially paused, where only redeem and settleVault is allowed
@@ -258,6 +260,12 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
 
         addressbook = AddressBookInterface(_addressBook);
         _refreshConfigInternal();
+    }
+
+    function donate(address _asset, uint256 _amount) external {
+        pool.transferToPool(_asset, msg.sender, _amount);
+
+        emit Donated(msg.sender, _asset, _amount);
     }
 
     /**

--- a/test/unit-tests/controller.test.ts
+++ b/test/unit-tests/controller.test.ts
@@ -4860,5 +4860,23 @@ contract(
         await expectRevert.unspecified(controllerProxy.operate(actionArgs, {from: accountOwner1}))
       })
     })
+
+    describe('Donate to pool', () => {
+      it('it should donate to margin pool', async () => {
+        const amountToDonate = createTokenAmount(100, usdcDecimals)
+        const storedBalanceBefore = new BigNumber(await marginPool.getStoredBalance(usdc.address))
+
+        await usdc.approve(marginPool.address, amountToDonate, {from: random})
+        await controllerProxy.donate(usdc.address, amountToDonate, {from: random})
+
+        const storedBalanceAfter = new BigNumber(await marginPool.getStoredBalance(usdc.address))
+
+        assert.equal(
+          storedBalanceAfter.minus(storedBalanceBefore).toString(),
+          amountToDonate,
+          'Donated amount mismatch',
+        )
+      })
+    })
   },
 )

--- a/test/unit-tests/controller.test.ts
+++ b/test/unit-tests/controller.test.ts
@@ -46,7 +46,7 @@ enum ActionType {
 
 contract(
   'Controller',
-  ([owner, accountOwner1, accountOwner2, accountOperator1, holder1, fullPauser, partialPauser, random]) => {
+  ([owner, accountOwner1, accountOwner2, accountOperator1, holder1, fullPauser, partialPauser, random, donor]) => {
     // ERC20 mock
     let usdc: MockERC20Instance
     let weth: MockERC20Instance
@@ -112,6 +112,7 @@ contract(
       await usdc.mint(accountOwner1, createTokenAmount(10000, usdcDecimals))
       await usdc.mint(accountOperator1, createTokenAmount(10000, usdcDecimals))
       await usdc.mint(random, createTokenAmount(10000, usdcDecimals))
+      await usdc.mint(donor, createTokenAmount(10000, usdcDecimals))
     })
 
     describe('Controller initialization', () => {
@@ -4810,6 +4811,24 @@ contract(
       })
     })
 
+    describe('Donate to pool', () => {
+      it('it should donate to margin pool', async () => {
+        const amountToDonate = createTokenAmount(10, usdcDecimals)
+        const storedBalanceBefore = new BigNumber(await marginPool.getStoredBalance(usdc.address))
+
+        await usdc.approve(marginPool.address, amountToDonate, {from: donor})
+        await controllerProxy.donate(usdc.address, amountToDonate, {from: donor})
+
+        const storedBalanceAfter = new BigNumber(await marginPool.getStoredBalance(usdc.address))
+
+        assert.equal(
+          storedBalanceAfter.minus(storedBalanceBefore).toString(),
+          amountToDonate,
+          'Donated amount mismatch',
+        )
+      })
+    })
+
     describe('Refresh configuration', () => {
       it('should revert refreshing configuration from address other than owner', async () => {
         await expectRevert(controllerProxy.refreshConfiguration({from: random}), 'Ownable: caller is not the owner')
@@ -4858,24 +4877,6 @@ contract(
 
         await usdc.approve(marginPool.address, collateralToDeposit, {from: accountOwner1})
         await expectRevert.unspecified(controllerProxy.operate(actionArgs, {from: accountOwner1}))
-      })
-    })
-
-    describe('Donate to pool', () => {
-      it('it should donate to margin pool', async () => {
-        const amountToDonate = createTokenAmount(100, usdcDecimals)
-        const storedBalanceBefore = new BigNumber(await marginPool.getStoredBalance(usdc.address))
-
-        await usdc.approve(marginPool.address, amountToDonate, {from: random})
-        await controllerProxy.donate(usdc.address, amountToDonate, {from: random})
-
-        const storedBalanceAfter = new BigNumber(await marginPool.getStoredBalance(usdc.address))
-
-        assert.equal(
-          storedBalanceAfter.minus(storedBalanceBefore).toString(),
-          amountToDonate,
-          'Donated amount mismatch',
-        )
       })
     })
   },


### PR DESCRIPTION
# Task: Add donate feature

## High Level Description

Add `donate()` to send a specific asset amount to `MarginPool` while still getting accounted in `assetBalance`.

### Code

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?

### Documentation

- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
