### PR TITLE
Chore: remove certora from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,9 @@ workflows:
       - lint:
           requires:
             - build
-      - certora:
-          requires:
-            - coverage
+      #- certora:
+      #    requires:
+      #      - coverage
       - size-check:
           requires:
             - build


### PR DESCRIPTION
# Chore: remove certora from CircleCI

## High Level Description

Removing Certora from CircleCI jobs for now until all issues get fixed.

### Code

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?

### Documentation

- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
