### PR TITLE
Fix: Integration test assertions

### DIFF
--- a/test/integration-tests/nakedMarginCallPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginCallPreExpiry.test.ts
@@ -674,7 +674,7 @@ contract('Naked margin: call position pre expiry', ([owner, accountOwner1, liqui
       )
       assert.equal(
         userVaultAfter[0].collateralAmounts[0].toString(),
-        new BigNumber(userVaultBefore[0].collateralAmounts[0]).minus(isLiquidatable[1].toString()).toString(),
+        new BigNumber(userVaultBefore[0].collateralAmounts[0]).minus(new BigNumber(isLiquidatable[1])).toString(),
         'User vault short amount mismatch after liquidation',
       )
     })

--- a/test/integration-tests/nakedMarginPutPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginPutPreExpiry.test.ts
@@ -403,7 +403,7 @@ contract('Naked margin: put position pre expiry', ([owner, accountOwner1, buyer1
           new BigNumber(vaultAfterLiquidation.collateralAmounts[0]),
           new BigNumber(vaultBeforeLiquidation.collateralAmounts[0]).minus(new BigNumber(isLiquidatable[1])),
         )
-          .dividedBy(10 ** usdcDecimals)
+          .dividedBy(new BigNumber(10 ** usdcDecimals))
           .toNumber(),
         errorDelta,
         'Vault collateral mismatch after liquidation',

--- a/test/integration-tests/nakedMarginPutPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginPutPreExpiry.test.ts
@@ -399,7 +399,6 @@ contract('Naked margin: put position pre expiry', ([owner, accountOwner1, buyer1
       const vaultAfterLiquidation = (await controllerProxy.getVault(accountOwner1, vaultCounter.toString()))[0]
 
       assert.equal(vaultAfterLiquidation.shortAmounts[0].toString(), '0', 'Vault was not fully liquidated')
-      console.log('after', vaultAfterLiquidation.collateralAmounts)
       assert.isAtMost(
         calcRelativeDiff(
           new BigNumber(vaultAfterLiquidation.collateralAmounts[0]),
@@ -676,8 +675,8 @@ contract('Naked margin: put position pre expiry', ([owner, accountOwner1, buyer1
         'Liquidator vault short amount mismatch',
       )
       assert.equal(
-        userVaultAfter[0].collateralAmounts[0].toString(),
-        new BigNumber(userVaultBefore[0].collateralAmounts[0]).minus(isLiquidatable[1].toString()).toString(),
+        new BigNumber(userVaultAfter[0].collateralAmounts[0]).toString(),
+        new BigNumber(userVaultBefore[0].collateralAmounts[0]).minus(new BigNumber(isLiquidatable[1])).toString(),
         'User vault short amount mismatch after liquidation',
       )
     })

--- a/test/integration-tests/nakedMarginPutPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginPutPreExpiry.test.ts
@@ -274,7 +274,9 @@ contract('Naked margin: put position pre expiry', ([owner, accountOwner1, buyer1
         isPut,
       )
       const userVaultBefore = await controllerProxy.getVault(accountOwner1, vaultCounter)
-      const amountToWithdraw = new BigNumber(userVaultBefore[0].collateralAmounts[0]).minus(collateralNeeded)
+      const amountToWithdraw = new BigNumber(userVaultBefore[0].collateralAmounts[0]).minus(
+        new BigNumber(collateralNeeded),
+      )
       const withdrawArgs = [
         {
           actionType: ActionType.WithdrawCollateral,

--- a/test/integration-tests/nakedMarginPutPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginPutPreExpiry.test.ts
@@ -397,9 +397,10 @@ contract('Naked margin: put position pre expiry', ([owner, accountOwner1, buyer1
       const vaultAfterLiquidation = (await controllerProxy.getVault(accountOwner1, vaultCounter.toString()))[0]
 
       assert.equal(vaultAfterLiquidation.shortAmounts[0].toString(), '0', 'Vault was not fully liquidated')
+      console.log('after', vaultAfterLiquidation.collateralAmounts)
       assert.isAtMost(
         calcRelativeDiff(
-          vaultAfterLiquidation.collateralAmounts[0],
+          new BigNumber(vaultAfterLiquidation.collateralAmounts[0]),
           new BigNumber(vaultBeforeLiquidation.collateralAmounts[0]).minus(new BigNumber(isLiquidatable[1])),
         )
           .dividedBy(10 ** usdcDecimals)


### PR DESCRIPTION
- fix: convert `isLiquidatable` `BN` to `BigNumber` in `nakedMarginCallPreExpiry` integration test
- fix: convert `vaultAfterLiquidation.collateralAmounts` to `BigNumber` in `nakedMarginPutPreExpiry` integration test
- fix: convert denominator in assertion to `BigNumber` in `nakedMarginPutPreExpiry` integration test
- fix: convert `collateralNeeded` to `BigNumber` in `nakedMarginPutPreExpiry` integration test
- fix: convert `userVaultAfter.collateralAmounts` & `isLiquidatable` to `BigNumber` in `nakedMarginPutPreExpiry` integration test