### PR TITLE
[TOB-OPYN-013] return 0 instead of absolute value if isExcess is false

### DIFF
--- a/contracts/core/Controller.sol
+++ b/contracts/core/Controller.sol
@@ -465,7 +465,10 @@ contract Controller is Initializable, OwnableUpgradeSafe, ReentrancyGuardUpgrade
     function getProceed(address _owner, uint256 _vaultId) external view returns (uint256) {
         (MarginVault.Vault memory vault, uint256 typeVault, ) = getVault(_owner, _vaultId);
 
-        (uint256 netValue, ) = calculator.getExcessCollateral(vault, typeVault);
+        (uint256 netValue, bool isExcess) = calculator.getExcessCollateral(vault, typeVault);
+
+        if (!isExcess) return 0;
+
         return netValue;
     }
 


### PR DESCRIPTION
# Audit-fix: [TOB-OPYN-013] return 0 instead of absolute value if isExcess is false

## High Level Description

This PR update the `getProceed()` to return 0 when there is no excess in the vault instead of returning the absolute net value.

### Code

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?

### Documentation

- [x] Is your code up to date with the spec? 
- [x] Have you added your tests to the testing doc?
