### PR TITLE
[TOB-OPYN-016] Remove underlying decimals for YearnPricer

### DIFF
--- a/contracts/pricers/YearnPricer.sol
+++ b/contracts/pricers/YearnPricer.sol
@@ -23,9 +23,6 @@ contract YearnPricer is OpynPricerInterface {
     /// @notice underlying asset for this yToken
     ERC20Interface public underlying;
 
-    /// @notice decimals for the underlying asset
-    uint8 public underlyingDecimals;
-
     /**
      * @param _yToken yToken asset
      * @param _underlying underlying asset for this yToken
@@ -40,10 +37,8 @@ contract YearnPricer is OpynPricerInterface {
         require(_underlying != address(0), "YearnPricer: underlying address can not be 0");
         require(_oracle != address(0), "YearnPricer: oracle address can not be 0");
 
-        ERC20Interface underlyingToken = ERC20Interface(_underlying);
-        underlyingDecimals = underlyingToken.decimals();
         yToken = YearnVaultInterface(_yToken);
-        underlying = underlyingToken;
+        underlying = ERC20Interface(_underlying);
         oracle = OracleInterface(_oracle);
     }
 
@@ -77,6 +72,8 @@ contract YearnPricer is OpynPricerInterface {
      */
     function _underlyingPriceToYtokenPrice(uint256 _underlyingPrice) private view returns (uint256) {
         uint256 pricePerShare = yToken.pricePerShare();
+        uint8 underlyingDecimals = underlyingToken.decimals();
+
         return pricePerShare.mul(_underlyingPrice).div(10**uint256(underlyingDecimals));
     }
 


### PR DESCRIPTION
# Audit-fix: [TOB-OPYN-016] Remove underlying decimals for YearnPricer

## High Level Description

This PR remove the underlying decimals from the YearnPricer and fetch it every time the price is requested.

### Code

- [ ] Unit test 100% coverage
- [ ] Does your code follow the naming and code documentation guidelines?

### Documentation

- [ ] Is your code up to date with the spec? 
- [ ] Have you added your tests to the testing doc?
