### PR TITLE
Feature: add cap amount for naked margin collateral

### DIFF
--- a/contracts/core/MarginCalculator.sol
+++ b/contracts/core/MarginCalculator.sol
@@ -261,7 +261,7 @@ contract MarginCalculator is Ownable {
     /**
      * @notice get cap amount for collateral asset
      * @param _collateral collateral asset address
-     * @return dust amount
+     * @return cap amount
      */
     function getCollateralCap(address _collateral) external view returns (uint256) {
         return cap[_collateral];

--- a/contracts/core/MarginCalculator.sol
+++ b/contracts/core/MarginCalculator.sol
@@ -120,7 +120,7 @@ contract MarginCalculator is Ownable {
      * @notice set cap amount for collateral asset used in naked margin
      * @dev can only be called by owner
      * @param _collateral collateral asset address
-     * @param _cap dust amount, should be scaled by collateral asset decimals
+     * @param _cap cap amount, should be scaled by collateral asset decimals
      */
     function setCollateralCap(address _collateral, uint256 _cap) external onlyOwner {
         require(_cap > 0, "MarginCalculator: cap amount should be greater than zero");

--- a/contracts/core/MarginCalculator.sol
+++ b/contracts/core/MarginCalculator.sol
@@ -674,7 +674,7 @@ contract MarginCalculator is Ownable {
                     _vaultDetails.collateralDecimals
                 );
 
-                // fetch collateral cap amount for otoken collateral asset as FixedPointInt, assuming dust is already scaled by collateral decimals
+                // fetch collateral cap amount for otoken collateral asset as FixedPointInt, assuming cap is already scaled by collateral decimals
                 FPI.FixedPointInt memory capAmount = FPI.fromScaledUint(
                     cap[_vaultDetails.shortCollateralAsset],
                     _vaultDetails.collateralDecimals

--- a/contracts/core/MarginCalculator.sol
+++ b/contracts/core/MarginCalculator.sol
@@ -117,6 +117,20 @@ contract MarginCalculator is Ownable {
     }
 
     /**
+     * @notice set cap amount for collateral asset used in naked margin
+     * @dev can only be called by owner
+     * @param _collateral collateral asset address
+     * @param _cap dust amount, should be scaled by collateral asset decimals
+     */
+    function setCollateralCap(address _collateral, uint256 _cap) external onlyOwner {
+        require(_cap > 0, "MarginCalculator: cap amount should be greater than zero");
+
+        cap[_collateral] = _cap;
+
+        emit CollateralCapUpdated(_collateral, _cap);
+    }
+
+    /**
      * @notice set product upper bound values
      * @dev can only be called by owner
      * @param _underlying otoken underlying asset
@@ -238,10 +252,19 @@ contract MarginCalculator is Ownable {
     /**
      * @notice get dust amount for collateral asset
      * @param _collateral collateral asset address
-     * @return dust amount (1e27)
+     * @return dust amount
      */
     function getCollateralDust(address _collateral) external view returns (uint256) {
         return dust[_collateral];
+    }
+
+    /**
+     * @notice get cap amount for collateral asset
+     * @param _collateral collateral asset address
+     * @return dust amount
+     */
+    function getCollateralCap(address _collateral) external view returns (uint256) {
+        return cap[_collateral];
     }
 
     /**

--- a/contracts/core/MarginCalculator.sol
+++ b/contracts/core/MarginCalculator.sol
@@ -62,6 +62,9 @@ contract MarginCalculator is Ownable {
     /// @dev mapping to store dust amount per option collateral asset (scaled by collateral asset decimals)
     mapping(address => uint256) internal dust;
 
+    /// @dev mapping to store cap amount per options collateral asset (scaled by collateral asset decimals)
+    mapping(address => uint256) internal cap;
+
     /// @dev mapping to store array of time to expiry for a given product
     mapping(bytes32 => uint256[]) internal timesToExpiryForProduct;
 
@@ -76,6 +79,8 @@ contract MarginCalculator is Ownable {
 
     /// @notice emits an event when collateral dust is updated
     event CollateralDustUpdated(address indexed collateral, uint256 dust);
+    /// @notice emits an event when collateral cap is updated
+    event CollateralCapUpdated(address indexed collateral, uint256 cap);
     /// @notice emits an event when new time to expiry is added for a specific product
     event TimeToExpiryAdded(bytes32 indexed productHash, uint256 timeToExpiry);
     /// @notice emits an event when new upper bound value is added for a specific time to expiry timestamp
@@ -640,9 +645,15 @@ contract MarginCalculator is Ownable {
             // it's not expired, return amount of margin required based on vault type
             if (_vaultDetails.vaultType == 1) {
                 // this is a naked margin vault
-                // fetch dust amount for otoken collateral asset as FixedPointInt, assuming dust is already scaled to 1e27
+                // fetch dust amount for otoken collateral asset as FixedPointInt, assuming dust is already scaled by collateral decimals
                 FPI.FixedPointInt memory dustAmount = FPI.fromScaledUint(
                     dust[_vaultDetails.shortCollateralAsset],
+                    _vaultDetails.collateralDecimals
+                );
+
+                // fetch collateral cap amount for otoken collateral asset as FixedPointInt, assuming dust is already scaled by collateral decimals
+                FPI.FixedPointInt memory capAmount = FPI.fromScaledUint(
+                    cap[_vaultDetails.shortCollateralAsset],
                     _vaultDetails.collateralDecimals
                 );
 
@@ -651,6 +662,11 @@ contract MarginCalculator is Ownable {
                     require(
                         collateralAmount.isGreaterThan(dustAmount),
                         "MarginCalculator: naked margin vault should have collateral amount greater than dust amount"
+                    );
+
+                    require(
+                        collateralAmount.isLessThanOrEqual(capAmount),
+                        "MarginCalculator: naked margin vault should have collateral amount less than cap amount"
                     );
                 }
 

--- a/test/integration-tests/nakedMarginCallPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginCallPreExpiry.test.ts
@@ -65,6 +65,7 @@ contract('Naked margin: call position pre expiry', ([owner, accountOwner1, liqui
     scaleNum(0.4603, 27),
   ]
   const wethDust = scaleNum(0.1, wethDecimals)
+  const wethCap = scaleNum(50000, wethDecimals)
   const shortStrike = 2000
   const isPut = false
   const shortAmount = 1
@@ -131,6 +132,7 @@ contract('Naked margin: call position pre expiry', ([owner, accountOwner1, liqui
     await calculator.setSpotShock(weth.address, usdc.address, weth.address, isPut, productSpotShockValue)
     await calculator.setOracleDeviation(oracleDeviationValue, {from: owner})
     await calculator.setCollateralDust(weth.address, wethDust, {from: owner})
+    await calculator.setCollateralCap(weth.address, wethCap, {from: owner})
     // set product upper bound values
     await calculator.setUpperBoundValues(weth.address, usdc.address, weth.address, isPut, timeToExpiry, expiryToValue, {
       from: owner,

--- a/test/integration-tests/nakedMarginPutPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginPutPreExpiry.test.ts
@@ -65,6 +65,7 @@ contract('Naked margin: put position pre expiry', ([owner, accountOwner1, buyer1
     scaleNum(0.4603, 27),
   ]
   const usdcDust = scaleNum(1, usdcDecimals)
+  const usdcCap = scaleNum(1000000, wethDecimals)
   const shortStrike = 2000
   const isPut = true // delta error because liquidation price differ based on block timestamp of isLiquidatable() and the actual liquidation tx
   const shortAmount = 1
@@ -131,6 +132,7 @@ contract('Naked margin: put position pre expiry', ([owner, accountOwner1, buyer1
     await calculator.setSpotShock(weth.address, usdc.address, usdc.address, isPut, productSpotShockValue)
     await calculator.setOracleDeviation(oracleDeviationValue, {from: owner})
     await calculator.setCollateralDust(usdc.address, usdcDust, {from: owner})
+    await calculator.setCollateralCap(usdc.address, usdcCap, {from: owner})
     // set product upper bound values
     await calculator.setUpperBoundValues(weth.address, usdc.address, usdc.address, isPut, timeToExpiry, expiryToValue, {
       from: owner,

--- a/test/unit-tests/controllerNakedMargin.test.ts
+++ b/test/unit-tests/controllerNakedMargin.test.ts
@@ -87,6 +87,8 @@ contract('Controller: naked margin', ([owner, accountOwner1, liquidator]) => {
   ]
   const wethDust = scaleNum(0.1, wethDecimals)
   const usdcDust = scaleNum(1, usdcDecimals)
+  const wethCap = scaleNum(50000, wethDecimals)
+  const usdcCap = scaleNum(1000000, wethDecimals)
 
   const errorDelta = 0.1
 
@@ -147,6 +149,9 @@ contract('Controller: naked margin', ([owner, accountOwner1, liquidator]) => {
     await calculator.setCollateralDust(weth.address, wethDust, {from: owner})
     // set USDC dust amount
     await calculator.setCollateralDust(usdc.address, usdcDust, {from: owner})
+    // set max cap
+    await calculator.setCollateralCap(usdc.address, usdcCap, {from: owner})
+    await calculator.setCollateralCap(weth.address, wethCap, {from: owner})
     // set product upper bound values
     await calculator.setUpperBoundValues(weth.address, usdc.address, usdc.address, true, timeToExpiry, expiryToValue, {
       from: owner,

--- a/test/unit-tests/liquidations.test.ts
+++ b/test/unit-tests/liquidations.test.ts
@@ -257,7 +257,11 @@ contract('MarginCalculator: liquidation', ([owner, random]) => {
       )
 
       assert.equal(isLiquidatable[0], true, 'isLiquidatable boolean value mismatch')
-      assert.equal(isLiquidatable[1].toNumber(), expectedLiquidationPrice, 'debt price value mismatch')
+      assert.equal(
+        new BigNumber(isLiquidatable[1].toString()).toString(),
+        new BigNumber(expectedLiquidationPrice).toString(),
+        'debt price value mismatch',
+      )
       assert.equal(isLiquidatable[2].toString(), usdcDust, 'collateral dust value mismatch')
     })
 

--- a/test/unit-tests/liquidations.test.ts
+++ b/test/unit-tests/liquidations.test.ts
@@ -39,6 +39,8 @@ contract('MarginCalculator: liquidation', ([owner, random]) => {
 
   const wethDust = scaleNum(1, 27)
   const usdcDust = scaleNum(1, 27)
+  const wethCap = scaleNum(50000, wethDecimals)
+  const usdcCap = scaleNum(1000000, wethDecimals)
 
   const vaultType = 1
 
@@ -75,6 +77,8 @@ contract('MarginCalculator: liquidation', ([owner, random]) => {
     // set collateral dust
     await calculator.setCollateralDust(weth.address, wethDust, {from: owner})
     await calculator.setCollateralDust(usdc.address, usdcDust, {from: owner})
+    await calculator.setCollateralCap(usdc.address, usdcCap, {from: owner})
+    await calculator.setCollateralCap(weth.address, wethCap, {from: owner})
     // set product spot shock value
     await calculator.setSpotShock(weth.address, usdc.address, usdc.address, true, productSpotShockValue)
     await calculator.setSpotShock(weth.address, usdc.address, weth.address, false, productSpotShockValue)

--- a/test/unit-tests/marginCalculatorNakedMargin.test.ts
+++ b/test/unit-tests/marginCalculatorNakedMargin.test.ts
@@ -428,6 +428,11 @@ contract('MarginCalculator: partial collateralization', ([owner, random]) => {
           from: owner,
         },
       )
+
+      await calculator.setCollateralDust(usdc.address, scaleNum(10, usdcDecimals))
+      await calculator.setCollateralDust(weth.address, scaleNum(0.01, wethDecimals))
+      await calculator.setCollateralCap(usdc.address, scaleNum(1000000, usdcDecimals))
+      await calculator.setCollateralCap(weth.address, scaleNum(50000, wethDecimals))
     })
 
     it('should return required margin for naked margin vault: 100$ WETH put option with 150 spot price and 1 week to expiry', async () => {
@@ -745,6 +750,7 @@ contract('MarginCalculator: partial collateralization', ([owner, random]) => {
       // update dust amount for this test case to work
       const usdcDust = scaleNum(expectedRequiredNakedMargin - 0.5, usdcDecimals)
       await calculator.setCollateralDust(usdc.address, usdcDust, {from: owner})
+      await calculator.setCollateralCap(usdc.address, scaleNum(50000, usdcDecimals), {from: owner})
 
       // set underlying price in oracle
       await oracle.setRealTimePrice(weth.address, scaledUnderlyingPrice)
@@ -815,7 +821,7 @@ contract('MarginCalculator: partial collateralization', ([owner, random]) => {
       assert.equal(getExcessCollateralResult[1], true, 'isValid vault result mismatch')
     })
 
-    it('should return false and the needed collateral amount for undercollateralized naked margin vault: 1 options 2500$ WETH call option with 1800 spot price and 1 week to expiry, ', async () => {
+    it('should return false and the needed collateral amount for undercollateralized naked margin vault: 1 options 2500$ WETH call option with 1800 spot price and 1 week to expiry,', async () => {
       const shortAmount = 1
       const shortStrike = 2500
       const underlyingPrice = 1800

--- a/test/unit-tests/marginCalculatorNakedMargin.test.ts
+++ b/test/unit-tests/marginCalculatorNakedMargin.test.ts
@@ -94,7 +94,7 @@ contract('MarginCalculator: partial collateralization', ([owner, random]) => {
   })
 
   describe('Collateral dust', async () => {
-    it('only owner should be able to set collateral dust amunt', async () => {
+    it('only owner should be able to set collateral dust amount', async () => {
       const wethDust = scaleNum(1, wethDecimals)
       await calculator.setCollateralDust(weth.address, wethDust, {from: owner})
 
@@ -118,6 +118,35 @@ contract('MarginCalculator: partial collateralization', ([owner, random]) => {
       await expectRevert(
         calculator.setCollateralDust(weth.address, wethDust, {from: owner}),
         'MarginCalculator: dust amount should be greater than zero',
+      )
+    })
+  })
+
+  describe('Collateral cap', async () => {
+    it('only owner should be able to set collateral cap amount', async () => {
+      const wethCap = scaleNum(50000, wethDecimals)
+      await calculator.setCollateralCap(weth.address, wethCap, {from: owner})
+
+      const capAmount = new BigNumber(await calculator.getCollateralCap(weth.address))
+
+      assert.equal(capAmount.toString(), wethCap.toString(), 'Weth dust amount mismatch')
+    })
+
+    it('should revert setting collateral cap from address other than owner', async () => {
+      const wethCap = scaleNum(50000, wethDecimals)
+
+      await expectRevert(
+        calculator.setCollateralCap(weth.address, wethCap, {from: random}),
+        'Ownable: caller is not the owner',
+      )
+    })
+
+    it('should revert setting collateral cap amount equal to zero', async () => {
+      const wethCap = scaleNum(0, wethDecimals)
+
+      await expectRevert(
+        calculator.setCollateralCap(weth.address, wethCap, {from: owner}),
+        'MarginCalculator: cap amount should be greater than zero',
       )
     })
   })


### PR DESCRIPTION
# Feature: add cap amount for naked margin collateral

## High Level Description

This PR add a cap amount for the collateral deposited in naked margin vault.
The cap amount is set per collateral asset, and should be scaled by the collateral asset decimals.

### Code

- [x] Unit test 100% coverage
- [x] Does your code follow the naming and code documentation guidelines?

### Documentation

- [x] Is your code up to date with the spec? 
- [ ] Have you added your tests to the testing doc?
