### PR TITLE
Fix: CI assertions

### DIFF
--- a/test/integration-tests/nakedMarginCallPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginCallPreExpiry.test.ts
@@ -684,9 +684,15 @@ contract('Naked margin: call position pre expiry', ([owner, accountOwner1, liqui
         createTokenAmount(0),
         'Liquidator vault short amount mismatch',
       )
-      assert.equal(
-        new BigNumber(userVaultAfter[0].collateralAmounts[0].toString()).toString(),
-        new BigNumber(userVaultBefore[0].collateralAmounts[0]).minus(new BigNumber(isLiquidatable[1])).toString(),
+
+      assert.isAtMost(
+        calcRelativeDiff(
+          new BigNumber(userVaultAfter[0].collateralAmounts[0]),
+          new BigNumber(userVaultBefore[0].collateralAmounts[0]).minus(new BigNumber(isLiquidatable[1])),
+        )
+          .dividedBy(new BigNumber(10 ** wethDecimals))
+          .toNumber(),
+        new BigNumber(errorDelta).toNumber(),
         'User vault short amount mismatch after liquidation',
       )
     })

--- a/test/integration-tests/nakedMarginPutPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginPutPreExpiry.test.ts
@@ -639,6 +639,7 @@ contract('Naked margin: put position pre expiry', ([owner, accountOwner1, buyer1
       )[0]
 
       assert.equal(vaultAfterLiquidation.shortAmounts[0].toString(), '0', 'Vault was not fully liquidated')
+
       assert.isAtMost(
         calcRelativeDiff(
           new BigNumber(vaultAfterLiquidation.collateralAmounts[0]),
@@ -649,16 +650,21 @@ contract('Naked margin: put position pre expiry', ([owner, accountOwner1, buyer1
         new BigNumber(errorDelta).toNumber(),
         'Vault collateral mismatch after liquidation',
       )
-      assert.equal(
-        liquidatorUsdcAfter.toString(),
-        liquidatorUsdcBefore.minus(collateralToDeposit).plus(isLiquidatable[1]).toString(),
+
+      assert.isAtMost(
+        calcRelativeDiff(liquidatorUsdcAfter, liquidatorUsdcBefore.minus(collateralToDeposit).plus(isLiquidatable[1]))
+          .dividedBy(new BigNumber(10 ** usdcDecimals))
+          .toNumber(),
+        new BigNumber(errorDelta).toNumber(),
         'Liquidator collateral balance mismatch after liquidation',
       )
+
       assert.equal(
         poolUsdcAfter.plus(isLiquidatable[1].toString()).minus(collateralToDeposit.toString()).toString(),
         poolUsdcBefore.toString(),
         'Pool balance after openining position mismatch',
       )
+
       assert.equal(
         liquidatorVaultAfter[0].collateralAmounts[0].toString(),
         collateralToDeposit.toString(),

--- a/test/integration-tests/nakedMarginPutPreExpiry.test.ts
+++ b/test/integration-tests/nakedMarginPutPreExpiry.test.ts
@@ -69,7 +69,7 @@ contract('Naked margin: put position pre expiry', ([owner, accountOwner1, buyer1
   const shortStrike = 2000
   const isPut = true // delta error because liquidation price differ based on block timestamp of isLiquidatable() and the actual liquidation tx
   const shortAmount = 1
-  const errorDelta = 0.1
+  const errorDelta = 0.25
 
   let addressBook: AddressBookInstance
   let calculator: MarginCalculatorInstance


### PR DESCRIPTION
- fix: `errorDelta` for naked margin put pre expiry integration tests to handle timestamp differences
- fix: convert user vault short amount mismatch assertion from `equal` to `isAtMost` to handle timestamp differences (naked margin call pre expiry integration test)
- fix: convert liquidator collateral balance mismatch assertion from `equal` to `isAtMost` to handle timestamp differences (naked margin put pre expiry integration test)